### PR TITLE
fix(docker): avoid delayed termination due to signal handling

### DIFF
--- a/symmetric-assemble/Dockerfile
+++ b/symmetric-assemble/Dockerfile
@@ -15,6 +15,9 @@ RUN mkdir -p /opt/
 RUN mv symmetric-server* /opt/symmetric-ds
 RUN chmod -R u=rwX,g=,o= /opt/symmetric-ds/security
 
+# Install tini
+RUN apk add --no-cache tini
+
 ENV SYM_HOME /opt/symmetric-ds
 
 # Create a volume containing the engines, tmp, conf, and security directories
@@ -26,4 +29,5 @@ VOLUME /opt/symmetric-ds/security
 EXPOSE 31415
 EXPOSE 31417
 
-CMD /opt/symmetric-ds/bin/sym_service start && tail -F /opt/symmetric-ds/logs/symmetric.log
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/bin/sh", "-c", "/opt/symmetric-ds/bin/sym_service start & tail -F /opt/symmetric-ds/logs/symmetric.log"]


### PR DESCRIPTION
This commit introduces `tini` (https://github.com/krallin/tini) as an init process for the container. This should fix several issues that arise from the current Docker setup.

Currently, the container runs `sym_service` via a shell command (`sh -c "/opt/symmetric-ds/bin/sym_service start && tail -F ..."`). This setup causes the shell to become PID 1, and signals such as `SIGTERM` or `SIGINT` sent to the container do not reliably reach `sym_service`. In practice, this leads to:

- Ctrl+C in local testing often times out because the service never receives the termination signal.
- `docker stop` commands take longer than necessary, as the service cannot shut down gracefully.
- Kubernetes deployments experience delayed pod termination.

Tini (https://github.com/krallin/tini) acts as a minimal init process that properly forwards termination signals to child processes. It is lightweight, widely adopted, and has been included in Docker since version 1.13.

With this change:
- `sym_service` will receive termination signals promptly.
- Local testing (Ctrl+C) and `docker stop` behave predictably.
- Kubernetes pod shutdown and rollout times are reduced and predictable.

The Dockerfile remains minimal and maintainable, with only a single dependency added.