### PR TITLE
SYM-7821: Change ClusteredCacheManager to degrade gracefully instead of throwing

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
@@ -193,7 +193,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public Set<String> getActiveServerIds() {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return new HashSet<>();
         }
         Set<String> active = new HashSet<>();
         if (peerNetworkCoordinator == null) {
@@ -327,7 +327,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public boolean isAnyPeerInState(String eventType) {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return false;
         }
         if (peerNetworkCoordinator == null) {
             return false;
@@ -344,7 +344,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public boolean isAnyPeerOnline() {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return false;
         }
         if (peerNetworkCoordinator == null) {
             return false;
@@ -369,7 +369,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public void broadcastEngineState(String engineName, ClusteredEngineState engineState) {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return;
         }
         engineAndPeerStateMap.put(getEngineStateMapKey(myServerId, engineName), engineState);
         if (isClusterPeerListenerStarted) {
@@ -380,7 +380,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public void rebroadcastCurrentState() {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return;
         }
         if (isClusterPeerListenerStarted) {
             broadcastCurrentStateAndEngines();
@@ -390,7 +390,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     @Override
     public boolean isAnyPeerWithEngineInState(String engineName, ClusteredEngineState engineState) {
         if (!isInitialized()) {
-            throw new RuntimeException("Service was not yet initialized!");
+            return false;
         }
         if (peerNetworkCoordinator == null) {
             return false;


### PR DESCRIPTION
ClusteredCacheManager (new in SYM-7674) hard-throws RuntimeException("Service was not yet initialized!") from broadcastEngineState() and the peer-query methods when !isInitialized(). SYM-7674 wired broadcastEngineState(...) into AbstractSymmetricEngine.setup()/start() — the universal startup path. But ClusteredCacheManager.initialize() is only ever called by SymmetricEngineHolder (the web/server layer). So any engine started without the web server — the service/embedded integration tests via ClientSymmetricEngine.start() — throws at startup, start()'s catch(Throwable) swallows it, and the sym schema is never created → every dependent test fails.   

This causes these integration test classes to fail:   

ProClusterServiceTest, JdbcTriggerRouterServiceTest, JdbcRouterServiceTest, JdbcDataLoaderServiceTest, JdbcDataExtractorServiceTest, DbExportImportTest, JdbcClusterServiceTest

The proposed fix is to have the 6 methods degrade gracefully when !isInitialized() instead of throwing: broadcastEngineState/rebroadcastCurrentState → no-op return; isAnyPeerOnline/isAnyPeerWithEngineInState/isAnyPeerInState → return false; getActiveServerIds → return empty set. 