### PR TITLE
fix: guard sync-triggers reconciler against transiently empty trigger config

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -377,6 +377,7 @@ final public class ParameterConstants {
     public static final String SYNC_TRIGGERS_TIMEOUT_IN_SECONDS = "sync.triggers.timeout.in.seconds";
     public static final String SYNC_TRIGGERS_REG_SVR_INSTALL_WITHOUT_CONFIG = "sync.triggers.reg.svr.install.without.config";
     public static final String SYNC_TRIGGERS_FIX_DUPLICATE_ACTIVE_TRIGGER_HISTORIES = "sync.triggers.fix.duplicate.active.trigger.histories";
+    public static final String SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY = "sync.triggers.skip.inactivation.when.config.empty";
     public static final String MONITOR_EVENTS_CAPTURE_ENABLED = "monitor.events.capture.enabled";
     public static final String HYBRID_PUSH_PULL_ENABLED = "hybrid.push.pull.enabled";
     public static final String HYBRID_PUSH_PULL_TIMEOUT = "hybrid.push.pull.timeout.ms";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
@@ -1669,7 +1669,16 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
                         ts = System.currentTimeMillis();
                         List<TriggerHistory> activeTriggerHistories = getActiveTriggerHistories();
                         context.incrementActiveTriggerHistoriesTime(System.currentTimeMillis() - ts);
-                        inactivateTriggers(triggersForCurrentNode, sqlBuffer, activeTriggerHistories, context);
+                        if (shouldSkipInactivationForEmptyConfig(triggersForCurrentNode, activeTriggerHistories, createTriggersForTables)) {
+                            log.warn("Trigger configuration for this node read back empty while {} active trigger "
+                                    + "capture histories exist. Skipping trigger inactivation this run to avoid dropping "
+                                    + "all capture triggers because of what is likely a transient/in-flight configuration "
+                                    + "reload (e.g. a config delete has replicated but its re-insert has not yet been "
+                                    + "applied); this will reconcile on a subsequent sync triggers run.",
+                                    activeTriggerHistories.size());
+                        } else {
+                            inactivateTriggers(triggersForCurrentNode, sqlBuffer, activeTriggerHistories, context);
+                        }
                         updateOrCreateDatabaseTriggers(triggersForCurrentNode, sqlBuffer, force,
                                 true, activeTriggerHistories, true, context);
                         resetTriggerRouterCacheByNodeGroupId();
@@ -1746,6 +1755,32 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
             numThreads = 1;
         }
         return numThreads;
+    }
+
+    /**
+     * Determines whether the inactivation/drop pass in {@link #inactivateTriggers(List, StringBuilder, List, TriggerRouterContext)} should be skipped this
+     * run because the trigger configuration for this node was read back unexpectedly empty while active trigger capture histories still exist.
+     * <p>
+     * Under normal operation, {@code triggersForCurrentNode} being empty means every table's capture should be inactivated -- that is also the
+     * <em>intentional</em> behavior when {@code createTriggersForTables} is false (initial load in progress), so this guard must never apply in that case;
+     * see the {@code triggersForCurrentNode.clear()} call in {@link #syncTriggers(StringBuilder, boolean)}.
+     * <p>
+     * However, when trigger creation IS enabled ({@code createTriggersForTables} is true) and the configuration nonetheless reads back empty, that is very
+     * likely a transient/in-flight configuration state -- e.g. a non-atomic configuration reseed where a delete has replicated to this node before its
+     * corresponding re-insert has been applied -- rather than a legitimate "drop every capture trigger" instruction. Skipping inactivation in that narrow
+     * window avoids destructively dropping every trigger; the next sync triggers run will reconcile once the configuration is complete again.
+     *
+     * @param triggersForCurrentNode the triggers read from configuration for this node
+     * @param activeTriggerHistories the trigger histories currently marked active/inactivated in the database
+     * @param createTriggersForTables whether trigger creation is enabled for this run (false only during the intentional initial-load clear)
+     * @return true if the inactivation pass should be skipped this run
+     */
+    protected boolean shouldSkipInactivationForEmptyConfig(List<Trigger> triggersForCurrentNode,
+            List<TriggerHistory> activeTriggerHistories, boolean createTriggersForTables) {
+        return createTriggersForTables
+                && parameterService.is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true)
+                && (triggersForCurrentNode == null || triggersForCurrentNode.isEmpty())
+                && activeTriggerHistories != null && !activeTriggerHistories.isEmpty();
     }
 
     protected void inactivateTriggers(final List<Trigger> triggersThatShouldBeActive,

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -818,7 +818,19 @@ sync.triggers.reg.svr.install.without.config=true
 # Type: boolean
 sync.triggers.fix.duplicate.active.trigger.histories=true
 
-# If this is true, when a configuration change is detected during routing, 
+# If this is true, and trigger creation for tables is enabled (i.e. this is not the initial-load-in-progress case where
+# table capture is intentionally cleared), sync triggers will skip the inactivation/drop step whenever the trigger
+# configuration read back from the database is unexpectedly empty while active trigger capture histories still exist.
+# This guards against a transient config state (e.g. a non-atomic config reseed where a delete has replicated but its
+# re-insert has not yet been applied) from being misread as "every table capture should be inactivated," which would
+# otherwise drop every capture trigger. The next sync triggers run will reconcile once the config is complete again.
+#
+# DatabaseOverridable: true
+# Tags: general
+# Type: boolean
+sync.triggers.skip.inactivation.when.config.empty=true
+
+# If this is true, when a configuration change is detected during routing,
 # symmetric will make sure table capture is up to date.
 #
 # DatabaseOverridable: true

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceTest.java
@@ -792,4 +792,67 @@ public class TriggerRouterServiceTest {
         assertEquals(1, pkColumns.length);
         assertEquals("id", pkColumns[0].getName());
     }
+
+    private TriggerHistory newTriggerHistory(String triggerId) {
+        TriggerHistory history = new TriggerHistory();
+        history.setTriggerId(triggerId);
+        return history;
+    }
+
+    @Test
+    void testShouldSkipInactivationForEmptyConfig_emptyConfigWithActiveHistoriesAndCreationEnabled_returnsTrue() throws Exception {
+        TriggerRouterService service = createSpyService();
+        when(parameterService.is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true)).thenReturn(true);
+        List<Trigger> emptyTriggers = new ArrayList<Trigger>();
+        List<TriggerHistory> activeHistories = new ArrayList<TriggerHistory>();
+        activeHistories.add(newTriggerHistory("test_trigger"));
+        boolean result = service.shouldSkipInactivationForEmptyConfig(emptyTriggers, activeHistories, true);
+        assertTrue(result);
+    }
+
+    @Test
+    void testShouldSkipInactivationForEmptyConfig_nonEmptyConfig_returnsFalse() throws Exception {
+        TriggerRouterService service = createSpyService();
+        when(parameterService.is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true)).thenReturn(true);
+        List<Trigger> nonEmptyTriggers = new ArrayList<Trigger>();
+        nonEmptyTriggers.add(newTrigger("test_trigger", "test_table"));
+        List<TriggerHistory> activeHistories = new ArrayList<TriggerHistory>();
+        activeHistories.add(newTriggerHistory("test_trigger"));
+        boolean result = service.shouldSkipInactivationForEmptyConfig(nonEmptyTriggers, activeHistories, true);
+        assertFalse(result);
+    }
+
+    @Test
+    void testShouldSkipInactivationForEmptyConfig_emptyActiveHistories_returnsFalse() throws Exception {
+        TriggerRouterService service = createSpyService();
+        when(parameterService.is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true)).thenReturn(true);
+        List<Trigger> emptyTriggers = new ArrayList<Trigger>();
+        List<TriggerHistory> emptyHistories = new ArrayList<TriggerHistory>();
+        boolean result = service.shouldSkipInactivationForEmptyConfig(emptyTriggers, emptyHistories, true);
+        assertFalse(result);
+    }
+
+    @Test
+    void testShouldSkipInactivationForEmptyConfig_initialLoadClearInProgress_returnsFalse() throws Exception {
+        // createTriggersForTables=false is the intentional initial-load clear path (see syncTriggers's
+        // triggersForCurrentNode.clear() call) -- the guard must never suppress inactivation there.
+        TriggerRouterService service = createSpyService();
+        List<Trigger> emptyTriggers = new ArrayList<Trigger>();
+        List<TriggerHistory> activeHistories = new ArrayList<TriggerHistory>();
+        activeHistories.add(newTriggerHistory("test_trigger"));
+        boolean result = service.shouldSkipInactivationForEmptyConfig(emptyTriggers, activeHistories, false);
+        assertFalse(result);
+        verify(parameterService, never()).is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true);
+    }
+
+    @Test
+    void testShouldSkipInactivationForEmptyConfig_parameterDisabled_returnsFalse() throws Exception {
+        TriggerRouterService service = createSpyService();
+        when(parameterService.is(ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY, true)).thenReturn(false);
+        List<Trigger> emptyTriggers = new ArrayList<Trigger>();
+        List<TriggerHistory> activeHistories = new ArrayList<TriggerHistory>();
+        activeHistories.add(newTriggerHistory("test_trigger"));
+        boolean result = service.shouldSkipInactivationForEmptyConfig(emptyTriggers, activeHistories, true);
+        assertFalse(result);
+    }
 }


### PR DESCRIPTION
See also Jira cards: 
https://jumpmind.atlassian.net/browse/SYM-7844
https://jumpmind.atlassian.net/browse/JMCH-2156

Adds a defensive guard so the sync-triggers reconciler cannot drop every capture trigger when the trigger configuration transiently reads back empty.

## The defect

`TriggerRouterService.syncTriggers(...)` reads the current node's trigger configuration into `triggersForCurrentNode`, then calls `inactivateTriggers(...)`, which looks up each active `TriggerHistory` by trigger id in that list. If the lookup misses (`trigger == null`), it logs "About to remove triggers for inactivated table" and drops the trigger.

This is the *intended* behavior when `createTriggersForTables` is `false` (initial load in progress — `triggersForCurrentNode.clear()` is called on purpose in that case). But there is no guard for the *unexpected* case: if `triggersForCurrentNode` comes back empty while trigger creation is otherwise enabled — e.g. because a non-atomic configuration reseed replicated a config delete before its corresponding re-insert was applied — every lookup misses and **every** active capture trigger gets inactivated/dropped fleet-wide, with nothing to force a rebuild until the config is complete again. This traces back to a downstream production outage (TPS ticket JMCH-2156) triggered by exactly this kind of transient config state.

## The fix

- Extracted the decision into a new protected, unit-testable helper, `shouldSkipInactivationForEmptyConfig(List<Trigger> triggersForCurrentNode, List<TriggerHistory> activeTriggerHistories, boolean createTriggersForTables)`, in `TriggerRouterService`.
- In `syncTriggers(...)`, just before the `inactivateTriggers(...)` call, if the helper returns `true`, the inactivation pass is skipped for this run and a `log.warn(...)` explains why (config read back empty while N active histories exist; likely transient/in-flight; will reconcile on the next sync-triggers run).
- The helper only returns `true` when `createTriggersForTables` is `true` — so it never touches the intentional initial-load clear path (`createTriggersForTables == false`), where dropping is still expected.
- Gated by a new parameter, `sync.triggers.skip.inactivation.when.config.empty` (`ParameterConstants.SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY`), defaulted to `true` (safe/guard-on) in `symmetric-default.properties`, `DatabaseOverridable: true` so it can be tuned/disabled per node if ever needed.
- `updateOrCreateDatabaseTriggers(...)` is unaffected (already a no-op on empty config) and continues to run every time.

## Files changed

- `symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java` — added `shouldSkipInactivationForEmptyConfig(...)`; wired the skip check into `syncTriggers(StringBuilder, boolean)` immediately before the existing `inactivateTriggers(...)` call.
- `symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java` — added `SYNC_TRIGGERS_SKIP_INACTIVATION_WHEN_CONFIG_EMPTY`.
- `symmetric-core/src/main/resources/symmetric-default.properties` — documented default (`true`) for the new parameter, following the existing `sync.triggers.*` doc-comment convention.
- `symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceTest.java` — added unit tests for `shouldSkipInactivationForEmptyConfig(...)`.

## Unit test

Five new tests exercising `shouldSkipInactivationForEmptyConfig(...)` directly (no database):
- empty config + non-empty active histories + trigger creation enabled → `true` (the guarded/positive case)
- non-empty config → `false`
- empty active histories → `false`
- `createTriggersForTables == false` (the intentional initial-load clear) → `false`, and the parameter is never even consulted in that path
- new parameter explicitly disabled → `false`

Ran narrowly: `./gradlew :symmetric-core:test --tests '*TriggerRouterServiceTest*'` (from `symmetric-assemble`, the Gradle root, with JDK 17 per `common.gradle`'s `sourceCompatibility`). Result: **29 tests, 0 failures, 0 errors** (24 pre-existing + 5 new) — `BUILD SUCCESSFUL`.

## Known limitations / notes

- This guard prevents the destructive drop, but it does not itself force a follow-up rebuild — it relies on the *next* `syncTriggers` run reading a complete configuration and reconciling normally. If the config never becomes complete again, capture would remain stale (though no worse than before this change, and vastly safer than dropping everything).
- Complementary config-side fixes (e.g. making the config reseed atomic, or ordering delete/re-insert replication) are out of scope here and tracked separately downstream.
- **This PR is a draft.** It is unit-tested only (`symmetric-core` module, no database) — it has not been run against a live SymmetricDS engine or exercised via integration tests, per the scope of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)