### PR TITLE
SYM-7733: Fixed db.client.connection.count metric not getting updated

### DIFF
--- a/symmetric-stats/src/main/java/org/jumpmind/symmetric/observability/metrics/MetricDefinitionFactory.java
+++ b/symmetric-stats/src/main/java/org/jumpmind/symmetric/observability/metrics/MetricDefinitionFactory.java
@@ -109,7 +109,7 @@ public class MetricDefinitionFactory implements IMetricDefinitionFactory {
             new SymMetricDefinition(METRIC_ID_DATA_UNROUTED_COUNT, "Total unrouted data rows", METRIC_UNIT_ROWS, InstrumentType.DOUBLE_GAUGE),
             // Runtime DB connection pool gauges
             new SymMetricDefinition(METRIC_ID_RUNTIME_DBPOOL_ACTIVE, "DB connection pool active connections", METRIC_UNIT_CONNECTIONS,
-                    InstrumentType.DOUBLE_GAUGE),
+                    InstrumentType.LONG_GAUGE),
             new SymMetricDefinition(METRIC_ID_RUNTIME_DBPOOL_IDLE, "DB connection pool idle connections", METRIC_UNIT_CONNECTIONS, InstrumentType.LONG_GAUGE),
             new SymMetricDefinition(METRIC_ID_RUNTIME_DBPOOL_UTILIZATION, "DB connection pool utilization as a percentage of max", METRIC_UNIT_PERCENT,
                     InstrumentType.DOUBLE_GAUGE),


### PR DESCRIPTION
The problem was that the Connection Pool Metrics monitor calls `IEngineMetricsService.getLongGauge()`, but the `db.client.connection.count` metric was defined with a double gauge.