### PR TITLE
SYM-7883: Prevent clearing cluster-peer locks when local engine is shutting down

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
@@ -766,7 +766,8 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
             }
         } else if (wasActive) {
             if (msg == null && !isClusterPeerListenerActive()) {
-                log.debug("Skipping detected peer-engine crash, because the local cluster peer communication is not (currently) initialized. Peer={}, engine={}",
+                log.debug(
+                        "Skipping detected peer-engine crash, because the local cluster peer communication is not (currently) initialized. Peer={}, engine={}",
                         peerId, engineName);
             } else {
                 engineAndPeerStateMap.put(key, ClusteredEngineState.OFFLINE);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
@@ -866,10 +866,10 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     }
 
     /**
-     * Required to catch disconnect in peer communication due to pending JVM shutdown. 
+     * Required to catch disconnect in peer communication due to pending JVM shutdown.
      */
     private boolean isClusterPeerListenerActive() {
-        if(!this.isClusterPeerListenerStarted) {
+        if (!this.isClusterPeerListenerStarted) {
             return false;
         }
         IClusterCacheCoordinator coordinator = peerNetworkCoordinator;
@@ -880,7 +880,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
         log.debug("Processing peer joined notification. Peer={}, version={}", msg.getServerId(), msg.getVersion());
         long peerStartTimeMs = msg.getStartTimeMs();
         for (ISymmetricEngine engine : registeredEngines.values()) {
-            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getParameterService().getEngineName());
+            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getEngineName());
             if (!authenticateAndJoinClusterPartition(engine, msg)) {
                 log.error("Aborting peer joined processing for peer={} because cluster partition authentication failed", msg.getServerId());
                 return;
@@ -963,7 +963,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
 
     private void stopRegisteredEngines() {
         for (ISymmetricEngine engine : registeredEngines.values()) {
-            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getParameterService().getEngineName());
+            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getEngineName());
             engine.stop();
         }
     }
@@ -984,7 +984,7 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
         log.warn("Engine {} on peer {} stopped sending cluster heartbeats! Clearing its orphaned locks.", engineName, peerId);
         MDC.put(LoggingConstants.CONTEXT_ENGINE, engineName);
         localEngine.getClusterService().clearLocksForServer(peerId);
-        localEngine.getNodeCommunicationService().clearLocksForServer(peerId);    
+        localEngine.getNodeCommunicationService().clearLocksForServer(peerId);
     }
 
     protected void onPeerLeft(String serverId) {
@@ -1004,12 +1004,12 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
 
     private void clearLocksForPeer(String serverId) {
         for (ISymmetricEngine engine : registeredEngines.values()) {
-            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getParameterService().getEngineName());
             if (!engine.isStarted()) {
                 log.debug("Skipping orphaned lock clearing for peer={} on engine={} because the local engine is not currently started",
                         serverId, engine.getEngineName());
                 continue;
             }
+            MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getEngineName());
             engine.getClusterService().clearLocksForServer(serverId);
             engine.getNodeCommunicationService().clearLocksForServer(serverId);
         }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
@@ -765,8 +765,13 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
                 log.warn("Received unparseable engine state from peer={}, engine={}, state={}", peerId, engineName, engineStateValue);
             }
         } else if (wasActive) {
-            engineAndPeerStateMap.put(key, ClusteredEngineState.OFFLINE);
-            onPeerEngineCrashed(peerId, engineName);
+            if (msg == null && !isClusterPeerListenerActive()) {
+                log.debug("Skipping engine crash detection for peer={}, engine={} because the local cluster communication layer is not currently "
+                        + "initialized - a null peer read cannot be trusted while our own communication layer is down", peerId, engineName);
+            } else {
+                engineAndPeerStateMap.put(key, ClusteredEngineState.OFFLINE);
+                onPeerEngineCrashed(peerId, engineName);
+            }
         }
     }
 
@@ -845,14 +850,30 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
                 onPeerJoined(messageFromPeer);
             }
         } else if (wasAlive) {
-            peerWasPreviouslyAlive.put(peerId, Boolean.FALSE);
-            if (messageFromPeer == null || messageFromPeer.isStale(now, staleThresholdMs)) {
-                onPeerCrashed(peerId);
+            if (messageFromPeer == null && !isClusterPeerListenerActive()) {
+                log.debug("Skipping peer crash/leave detection for peer={} because the local cluster communication layer is not currently initialized "
+                        + "- a null peer read cannot be trusted while our own communication layer is down", peerId);
             } else {
-                onPeerLeft(peerId);
+                peerWasPreviouslyAlive.put(peerId, Boolean.FALSE);
+                if (messageFromPeer == null || messageFromPeer.isStale(now, staleThresholdMs)) {
+                    onPeerCrashed(peerId);
+                } else {
+                    onPeerLeft(peerId);
+                }
             }
         }
         return peerIsActive;
+    }
+
+    /**
+     * Required to catch disconnect in peer communication due to pending JVM shutdown. 
+     */
+    private boolean isClusterPeerListenerActive() {
+        if(!this.isClusterPeerListenerStarted) {
+            return false;
+        }
+        IClusterCacheCoordinator coordinator = peerNetworkCoordinator;
+        return coordinator != null && coordinator.isInitialized();
     }
 
     protected void onPeerJoined(ClusterServerStatusMessage msg) {
@@ -955,13 +976,15 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     }
 
     protected void onPeerEngineCrashed(String peerId, String engineName) {
-        log.warn("Engine {} on peer {} stopped sending heartbeats. Clearing its orphaned locks.", engineName, peerId);
         ISymmetricEngine localEngine = registeredEngines.get(engineName);
-        if (localEngine != null) {
-            MDC.put(LoggingConstants.CONTEXT_ENGINE, engineName);
-            localEngine.getClusterService().clearLocksForServer(peerId);
-            localEngine.getNodeCommunicationService().clearLocksForServer(peerId);
+        if (localEngine == null || !localEngine.isStarted()) {
+            log.debug("Skipping orphaned lock clearing for peer={}, engine={} because the local engine is not currently started", peerId, engineName);
+            return;
         }
+        log.warn("Engine {} on peer {} stopped sending cluster heartbeats! Clearing its orphaned locks.", engineName, peerId);
+        MDC.put(LoggingConstants.CONTEXT_ENGINE, engineName);
+        localEngine.getClusterService().clearLocksForServer(peerId);
+        localEngine.getNodeCommunicationService().clearLocksForServer(peerId);    
     }
 
     protected void onPeerLeft(String serverId) {
@@ -982,6 +1005,11 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
     private void clearLocksForPeer(String serverId) {
         for (ISymmetricEngine engine : registeredEngines.values()) {
             MDC.put(LoggingConstants.CONTEXT_ENGINE, engine.getParameterService().getEngineName());
+            if (!engine.isStarted()) {
+                log.debug("Skipping orphaned lock clearing for peer={} on engine={} because the local engine is not currently started",
+                        serverId, engine.getEngineName());
+                continue;
+            }
             engine.getClusterService().clearLocksForServer(serverId);
             engine.getNodeCommunicationService().clearLocksForServer(serverId);
         }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ClusteredCacheManager.java
@@ -766,8 +766,8 @@ public class ClusteredCacheManager implements IClusteredCacheManager {
             }
         } else if (wasActive) {
             if (msg == null && !isClusterPeerListenerActive()) {
-                log.debug("Skipping engine crash detection for peer={}, engine={} because the local cluster communication layer is not currently "
-                        + "initialized - a null peer read cannot be trusted while our own communication layer is down", peerId, engineName);
+                log.debug("Skipping detected peer-engine crash, because the local cluster peer communication is not (currently) initialized. Peer={}, engine={}",
+                        peerId, engineName);
             } else {
                 engineAndPeerStateMap.put(key, ClusteredEngineState.OFFLINE);
                 onPeerEngineCrashed(peerId, engineName);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinator.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinator.java
@@ -99,9 +99,17 @@ public class JcsTcpCacheCoordinator implements IClusterCacheCoordinator {
         }
     }
 
+    /**
+     * Reflects the underlying JCS manager's own initialized state, not just whether this coordinator still holds a reference to it. Apache Commons JCS's
+     * CompositeCacheManager is a JVM-wide singleton that registers its own JVM shutdown hook the first time it's initialized; that hook can call
+     * jcsManager.shutDown() independently of (and concurrently with) this coordinator's own stop(), which would clear jcsManager's own isInitialized flag
+     * without nulling out our reference to it. Checking jcsManager.isInitialized() as well lets callers detect that condition instead of trusting a peer
+     * cache read that's silently backed by an already-disposed manager.
+     */
     @Override
     public boolean isInitialized() {
-        return jcsManager != null;
+        CompositeCacheManager manager = jcsManager;
+        return manager != null && manager.isInitialized();
     }
 
     public ClusterMessageConverter getConverter() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinator.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinator.java
@@ -103,8 +103,8 @@ public class JcsTcpCacheCoordinator implements IClusterCacheCoordinator {
      * Reflects the underlying JCS manager's own initialized state, not just whether this coordinator still holds a reference to it. Apache Commons JCS's
      * CompositeCacheManager is a JVM-wide singleton that registers its own JVM shutdown hook the first time it's initialized; that hook can call
      * jcsManager.shutDown() independently of (and concurrently with) this coordinator's own stop(), which would clear jcsManager's own isInitialized flag
-     * without nulling out our reference to it. Checking jcsManager.isInitialized() as well lets callers detect that condition instead of trusting a peer
-     * cache read that's silently backed by an already-disposed manager.
+     * without nulling out our reference to it. Checking jcsManager.isInitialized() as well lets callers detect that condition instead of trusting a peer cache
+     * read that's silently backed by an already-disposed manager.
      */
     @Override
     public boolean isInitialized() {

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
@@ -557,7 +557,7 @@ class ClusteredCacheManagerTest {
     }
 
     @Test
-    void onPeerCrashed_localEngineNotStarted_skipsLockClearing() throws Exception {
+    void onPeerCrashed_localEngineNotStarted_skipsLockClearing() {
         manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
         when(mockEngine.isStarted()).thenReturn(false);
         manager.onPeerCrashed(PEER_1);
@@ -566,7 +566,7 @@ class ClusteredCacheManagerTest {
     }
 
     @Test
-    void onPeerCrashed_localEngineStarted_clearsLocks() throws Exception {
+    void onPeerCrashed_localEngineStarted_clearsLocks() {
         manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
         manager.onPeerCrashed(PEER_1);
         verify(mockClusterService).clearLocksForServer(PEER_1);
@@ -574,7 +574,7 @@ class ClusteredCacheManagerTest {
     }
 
     @Test
-    void onPeerLeft_localEngineNotStarted_skipsLockClearing() throws Exception {
+    void onPeerLeft_localEngineNotStarted_skipsLockClearing() {
         manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
         when(mockEngine.isStarted()).thenReturn(false);
         manager.onPeerLeft(PEER_1);
@@ -583,7 +583,7 @@ class ClusteredCacheManagerTest {
     }
 
     @Test
-    void onPeerEngineCrashed_localEngineNotStarted_skipsLockClearing() throws Exception {
+    void onPeerEngineCrashed_localEngineNotStarted_skipsLockClearing() {
         manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
         when(mockEngine.isStarted()).thenReturn(false);
         manager.onPeerEngineCrashed(PEER_1, ENGINE_1);
@@ -597,7 +597,7 @@ class ClusteredCacheManagerTest {
     }
 
     @Test
-    void clearLocksForPeer_oneOfTwoLocalEnginesNotStarted_clearsOnlyForStartedEngine() throws Exception {
+    void clearLocksForPeer_oneOfTwoLocalEnginesNotStarted_clearsOnlyForStartedEngine() {
         IClusterService mockClusterService2 = mock(IClusterService.class);
         INodeCommunicationService mockNodeCommService2 = mock(INodeCommunicationService.class);
         when(mockEngine2.getClusterService()).thenReturn(mockClusterService2);

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
@@ -198,6 +198,12 @@ class ClusteredCacheManagerTest {
         setField("converter", value);
     }
 
+    private boolean callIsClusterPeerListenerActive() throws Exception {
+        Method method = ClusteredCacheManager.class.getDeclaredMethod("isClusterPeerListenerActive");
+        method.setAccessible(true);
+        return (boolean) method.invoke(manager);
+    }
+
     private boolean callIsOwnServerId(String serverId) throws Exception {
         Method method = ClusteredCacheManager.class.getDeclaredMethod("isOwnServerId", String.class);
         method.setAccessible(true);

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/ClusteredCacheManagerTest.java
@@ -106,7 +106,10 @@ class ClusteredCacheManagerTest {
         // Clustering must appear enabled, otherwise onPeerJoined() below routes into enforceClusterLockingOrExit(),
         // which can call System.exit() - fatal for the test JVM.
         when(mockClusterService.isClusteringEnabled()).thenReturn(true);
+        // Most tests assume a fully running local engine; tests exercising the not-started skip path override this explicitly.
+        when(mockEngine.isStarted()).thenReturn(true);
         when(mockEngine2.getEngineName()).thenReturn(ENGINE_2);
+        when(mockEngine2.isStarted()).thenReturn(true);
         manager = (ClusteredCacheManager) ClusteredCacheManager.getInstance();
         isPeerAliveMethod = ClusteredCacheManager.class.getDeclaredMethod("isPeerAlive", String.class, ClusterServerStatusMessage.class, long.class,
                 long.class);
@@ -468,6 +471,145 @@ class ClusteredCacheManagerTest {
         callDetectEngineState(PEER_1, ENGINE_1, offlineMsg, offlineMsg.getTimestamp() + 2, STALE_THRESHOLD_MS);
         verify(mockClusterService, times(1)).clearLocksForServer(PEER_1);
         verify(mockNodeCommService, times(1)).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void isClusterPeerListenerActive_listenerNotStarted_returnsFalse() throws Exception {
+        setField("isClusterPeerListenerStarted", false);
+        when(mockCoordinator.isInitialized()).thenReturn(true);
+        assertFalse(callIsClusterPeerListenerActive());
+    }
+
+    @Test
+    void isClusterPeerListenerActive_listenerStartedAndCoordinatorInitialized_returnsTrue() throws Exception {
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(true);
+        assertTrue(callIsClusterPeerListenerActive());
+    }
+
+    @Test
+    void isClusterPeerListenerActive_listenerStartedButCoordinatorNotInitialized_returnsFalse() throws Exception {
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(false);
+        assertFalse(callIsClusterPeerListenerActive());
+    }
+
+    @Test
+    void isClusterPeerListenerActive_coordinatorNull_returnsFalse() throws Exception {
+        setField("isClusterPeerListenerStarted", true);
+        setField("peerNetworkCoordinator", null);
+        assertFalse(callIsClusterPeerListenerActive());
+    }
+
+    @Test
+    void detectPeerStateAndFireEvents_aliveToNullMessage_coordinatorNotInitialized_skipsCrashDeclaration() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(false);
+        ClusterServerStatusMessage aliveMsg = new ClusterServerStatusMessage(ClusterServerStatusMessage.EVENT_PEER_HEARTBEAT, PEER_1, PARTITION_ID, 0L);
+        assertTrue(callDetectPeerState(PEER_1, aliveMsg, aliveMsg.getTimestamp() + 1, STALE_THRESHOLD_MS));
+        assertFalse(callDetectPeerState(PEER_1, null, System.currentTimeMillis(), STALE_THRESHOLD_MS));
+        assertEquals(Boolean.TRUE, peerWasPreviouslyAlive.get(PEER_1));
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void detectPeerStateAndFireEvents_aliveToNullMessage_coordinatorInitialized_stillFiresCrash() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(true);
+        ClusterServerStatusMessage aliveMsg = new ClusterServerStatusMessage(ClusterServerStatusMessage.EVENT_PEER_HEARTBEAT, PEER_1, PARTITION_ID, 0L);
+        assertTrue(callDetectPeerState(PEER_1, aliveMsg, aliveMsg.getTimestamp() + 1, STALE_THRESHOLD_MS));
+        assertFalse(callDetectPeerState(PEER_1, null, System.currentTimeMillis(), STALE_THRESHOLD_MS));
+        assertEquals(Boolean.FALSE, peerWasPreviouslyAlive.get(PEER_1));
+        verify(mockClusterService).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void detectEngineStateAndFireEvents_activeToNullMessage_coordinatorNotInitialized_skipsCrashDetection() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(false);
+        String key = EngineAndPeerStateMap.generateKey(PEER_1, ENGINE_1);
+        ClusterEngineStateMessage activeMsg = new ClusterEngineStateMessage(ClusteredEngineState.RUNNING, ENGINE_1, PEER_1, PARTITION_ID);
+        callDetectEngineState(PEER_1, ENGINE_1, activeMsg, activeMsg.getTimestamp() + 1, STALE_THRESHOLD_MS);
+        assertEquals(ClusteredEngineState.RUNNING, engineAndPeerStateMap.get(key));
+        callDetectEngineState(PEER_1, ENGINE_1, null, System.currentTimeMillis(), STALE_THRESHOLD_MS);
+        assertEquals(ClusteredEngineState.RUNNING, engineAndPeerStateMap.get(key));
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void detectEngineStateAndFireEvents_activeToNullMessage_coordinatorInitialized_stillFiresCrash() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        setField("isClusterPeerListenerStarted", true);
+        when(mockCoordinator.isInitialized()).thenReturn(true);
+        String key = EngineAndPeerStateMap.generateKey(PEER_1, ENGINE_1);
+        ClusterEngineStateMessage activeMsg = new ClusterEngineStateMessage(ClusteredEngineState.RUNNING, ENGINE_1, PEER_1, PARTITION_ID);
+        callDetectEngineState(PEER_1, ENGINE_1, activeMsg, activeMsg.getTimestamp() + 1, STALE_THRESHOLD_MS);
+        callDetectEngineState(PEER_1, ENGINE_1, null, System.currentTimeMillis(), STALE_THRESHOLD_MS);
+        assertEquals(ClusteredEngineState.OFFLINE, engineAndPeerStateMap.get(key));
+        verify(mockClusterService).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void onPeerCrashed_localEngineNotStarted_skipsLockClearing() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        when(mockEngine.isStarted()).thenReturn(false);
+        manager.onPeerCrashed(PEER_1);
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void onPeerCrashed_localEngineStarted_clearsLocks() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        manager.onPeerCrashed(PEER_1);
+        verify(mockClusterService).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void onPeerLeft_localEngineNotStarted_skipsLockClearing() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        when(mockEngine.isStarted()).thenReturn(false);
+        manager.onPeerLeft(PEER_1);
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void onPeerEngineCrashed_localEngineNotStarted_skipsLockClearing() throws Exception {
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        when(mockEngine.isStarted()).thenReturn(false);
+        manager.onPeerEngineCrashed(PEER_1, ENGINE_1);
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+    }
+
+    @Test
+    void onPeerEngineCrashed_engineNotRegistered_skipsLockClearingWithoutThrowing() {
+        assertDoesNotThrow(() -> manager.onPeerEngineCrashed(PEER_1, "unknownEngine"));
+    }
+
+    @Test
+    void clearLocksForPeer_oneOfTwoLocalEnginesNotStarted_clearsOnlyForStartedEngine() throws Exception {
+        IClusterService mockClusterService2 = mock(IClusterService.class);
+        INodeCommunicationService mockNodeCommService2 = mock(INodeCommunicationService.class);
+        when(mockEngine2.getClusterService()).thenReturn(mockClusterService2);
+        when(mockEngine2.getNodeCommunicationService()).thenReturn(mockNodeCommService2);
+        when(mockEngine.isStarted()).thenReturn(false);
+        manager.registerEngine(mockEngine, ClusteredEngineState.STARTING);
+        manager.registerEngine(mockEngine2, ClusteredEngineState.STARTING);
+        manager.onPeerCrashed(PEER_1);
+        verify(mockClusterService, never()).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService, never()).clearLocksForServer(PEER_1);
+        verify(mockClusterService2).clearLocksForServer(PEER_1);
+        verify(mockNodeCommService2).clearLocksForServer(PEER_1);
     }
 
     @Test

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinatorTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/cache/JcsTcpCacheCoordinatorTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.jcs3.access.CacheAccess;
 import org.apache.commons.jcs3.engine.control.CompositeCache;
+import org.apache.commons.jcs3.engine.control.CompositeCacheManager;
 import org.jumpmind.security.ISecurityService;
 import org.jumpmind.symmetric.cache.IClusterCacheCoordinator.CacheCoordinatorNetworkSettings;
 import org.jumpmind.symmetric.common.ServerConstants;
@@ -352,6 +353,27 @@ class JcsTcpCacheCoordinatorTest {
         coordinator.stop();
         assertFalse(coordinator.isInitialized());
         assertNull(coordinator.getPeerStatusMessage("server1"));
+    }
+
+    @Test
+    void isInitialized_underlyingJcsManagerShutDownIndependently_returnsFalse() throws Exception {
+        // Apache Commons JCS's CompositeCacheManager is a JVM-wide singleton that registers its own JVM shutdown hook the first
+        // time it's initialized. That hook can call shutDown() on the shared manager directly, independently of this coordinator's
+        // own stop(). isInitialized() must reflect that, not just whether this coordinator still holds a reference to the manager.
+        int port = findFreePort();
+        CacheCoordinatorNetworkSettings settings = new CacheCoordinatorNetworkSettings("server1", "inst1", port,
+                ServerConstants.CLUSTER_PEER_DISCOVERY_DB, 3000L);
+        try {
+            coordinator.start(settings, Collections.emptySet(), converter, new NodeHostCachePeerServerDiscovery());
+            assertTrue(coordinator.isInitialized());
+            Field jcsManagerField = JcsTcpCacheCoordinator.class.getDeclaredField("jcsManager");
+            jcsManagerField.setAccessible(true);
+            CompositeCacheManager manager = (CompositeCacheManager) jcsManagerField.get(coordinator);
+            manager.shutDown();
+            assertFalse(coordinator.isInitialized());
+        } finally {
+            coordinator.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
Prevent clearing peer locks when local engine is shutting down.
Detect own shutdown and ignore peer messages