### PR TITLE
SYM-7891: Fix slow Routing job when node cache misses, nodes list is empty

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -781,6 +781,40 @@ public class RouterService extends AbstractService implements IRouterService, IN
         return nodes;
     }
 
+    protected Collection<String> findNodeIdsFromNodeList(Data data, TriggerRouter triggerRouter, ChannelRouterContext context) {
+        List<String> targetNodeIds = Arrays.asList(data.getNodeList().split(","));
+        Collection<String> nodeIds = CollectionUtils.intersection(targetNodeIds, toNodeIds(findAvailableNodes(triggerRouter, context)));
+        Collection<String> missingNodeIds = CollectionUtils.subtract(targetNodeIds, nodeIds);
+        if (isNodeCacheRefreshNeeded(missingNodeIds, triggerRouter)) {
+            engine.getNodeService().flushNodeGroupCache();
+            context.getAvailableNodes().remove(triggerRouter);
+            nodeIds = CollectionUtils.intersection(targetNodeIds, toNodeIds(findAvailableNodes(triggerRouter, context)));
+        }
+        if (nodeIds.isEmpty() && log.isDebugEnabled()) {
+            log.debug(
+                    "None of the target nodes specified in the data.node_list field ({}) were qualified nodes. Data id {} for table '{}' will not be routed using the {} router",
+                    new Object[] { data.getNodeList(), data.getDataId(), data.getTableName(), triggerRouter.getRouter().getRouterId() });
+        }
+        return nodeIds;
+    }
+
+    /**
+     * Tells whether refreshing the node cache can resolve any of the missing nodes, which is only true for a node the
+     * cache has not seen yet as an enabled member of the router's target node group. Any other missing node stays
+     * unresolved after a refresh, so refreshing would re-read every enabled node on EVERY data row (expensive!) for nothing.
+     */
+    protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter) {
+        String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
+        for (String missingNodeId : missingNodeIds) {
+            Node missingNode = engine.getNodeService().findNode(missingNodeId);
+            if (missingNode != null && missingNode.isSyncEnabled() 
+                    && StringUtils.equals(targetNodeGroupId, missingNode.getNodeGroupId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     protected IDataToRouteReader createReader(ChannelRouterContext context) {
         return AppUtils.newInstance(DataGapRouteReader.class, DataGapRouteReader.class,
                 new Object[] { context, engine },
@@ -976,22 +1010,8 @@ public class RouterService extends AbstractService implements IRouterService, IN
                 DataMetaData dataMetaData = new DataMetaData(data, table, router, context.getChannel());
                 Collection<String> nodeIds = null;
                 if (triggerRouter.isRouted(data.getDataEventType())) {
-                    String targetNodeIds = data.getNodeList();
-                    if (StringUtils.isNotBlank(targetNodeIds)) {
-                        List<String> targetNodeIdsList = Arrays.asList(targetNodeIds.split(","));
-                        nodeIds = CollectionUtils.intersection(targetNodeIdsList, toNodeIds(findAvailableNodes(triggerRouter, context)));
-                        if (targetNodeIdsList.size() > nodeIds.size()) {
-                            // Missing some nodes from the cache
-                            // Clear cache and try again
-                            engine.getNodeService().flushNodeGroupCache();
-                            context.getAvailableNodes().remove(triggerRouter);
-                            nodeIds = CollectionUtils.intersection(targetNodeIdsList, toNodeIds(findAvailableNodes(triggerRouter, context)));
-                        }
-                        if (nodeIds.size() == 0 && log.isDebugEnabled()) {
-                            log.debug(
-                                    "None of the target nodes specified in the data.node_list field ({}) were qualified nodes. Data id {} for table '{}' will not be routed using the {} router",
-                                    new Object[] { targetNodeIds, data.getDataId(), data.getTableName(), router.getRouterId() });
-                        }
+                    if (StringUtils.isNotBlank(data.getNodeList())) {
+                        nodeIds = findNodeIdsFromNodeList(data, triggerRouter, context);
                     } else if (data.getTriggerHistory().getLastTriggerBuildReason() == TriggerReBuildReason.TRIGGER_HIST_MISSING && !doesColumnCountMatchValues(
                             dataMetaData, data)) {
                         Integer triggerHistId = data.getTriggerHistory().getTriggerHistoryId();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -799,15 +799,15 @@ public class RouterService extends AbstractService implements IRouterService, IN
     }
 
     /**
-     * Tells whether refreshing the node cache can resolve any of the missing nodes, which is only true for a node the
-     * cache has not seen yet as an enabled member of the router's target node group. Any other missing node stays
-     * unresolved after a refresh, so refreshing would re-read every enabled node on EVERY data row (expensive!) for nothing.
+     * Tells whether refreshing the node cache can resolve any of the missing nodes, which is only true for a node the cache has not seen yet as an enabled
+     * member of the router's target node group. Any other missing node stays unresolved after a refresh, so refreshing would re-read every enabled node on
+     * EVERY data row (expensive!) for nothing.
      */
     protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter) {
         String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
         for (String missingNodeId : missingNodeIds) {
             Node missingNode = engine.getNodeService().findNode(missingNodeId);
-            if (missingNode != null && missingNode.isSyncEnabled() 
+            if (missingNode != null && missingNode.isSyncEnabled()
                     && StringUtils.equals(targetNodeGroupId, missingNode.getNodeGroupId())) {
                 return true;
             }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -801,11 +801,16 @@ public class RouterService extends AbstractService implements IRouterService, IN
     /**
      * Tells whether refreshing the node cache can resolve any of the missing nodes, which is only true for a node the cache has not seen yet as an enabled
      * member of the router's target node group. Any other missing node stays unresolved after a refresh, so refreshing would re-read every enabled node on
-     * EVERY data row (expensive!) for nothing. A node the channel ignores or a grouplet excludes is unresolvable too, because rebuilding the available nodes
-     * re-applies those filters from caches that a node cache refresh does not touch, so this method must mirror the filters in findAvailableNodes.
+     * EVERY data row (expensive!) for nothing. A router whose node group link is gone, a node the channel ignores, and a node a grouplet excludes are all
+     * unresolvable for the same reason: rebuilding the available nodes re-applies those filters from caches that a node cache refresh does not touch. This
+     * method must therefore mirror every filter in findAvailableNodes.
      */
     protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter, NodeChannel channel) {
-        String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
+        NodeGroupLink routerLink = triggerRouter.getRouter().getNodeGroupLink();
+        if (engine.getConfigurationService().getNodeGroupLinkFor(routerLink.getSourceNodeGroupId(), routerLink.getTargetNodeGroupId(), false) == null) {
+            return false;
+        }
+        String targetNodeGroupId = routerLink.getTargetNodeGroupId();
         for (String missingNodeId : missingNodeIds) {
             if (channel.isIgnoreEnabled(missingNodeId)) {
                 continue;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -804,9 +804,6 @@ public class RouterService extends AbstractService implements IRouterService, IN
      * EVERY data row (expensive!) for nothing.
      */
     protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter) {
-        if (!missingNodeIds.isEmpty()) {
-            return true;
-        }
         String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
         for (String missingNodeId : missingNodeIds) {
             Node missingNode = engine.getNodeService().findNode(missingNodeId);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -785,7 +785,7 @@ public class RouterService extends AbstractService implements IRouterService, IN
         List<String> targetNodeIds = Arrays.asList(data.getNodeList().split(","));
         Collection<String> nodeIds = CollectionUtils.intersection(targetNodeIds, toNodeIds(findAvailableNodes(triggerRouter, context)));
         Collection<String> missingNodeIds = CollectionUtils.subtract(targetNodeIds, nodeIds);
-        if (isNodeCacheRefreshNeeded(missingNodeIds, triggerRouter)) {
+        if (isNodeCacheRefreshNeeded(missingNodeIds, triggerRouter, context.getChannel())) {
             engine.getNodeService().flushNodeGroupCache();
             context.getAvailableNodes().remove(triggerRouter);
             nodeIds = CollectionUtils.intersection(targetNodeIds, toNodeIds(findAvailableNodes(triggerRouter, context)));
@@ -801,14 +801,19 @@ public class RouterService extends AbstractService implements IRouterService, IN
     /**
      * Tells whether refreshing the node cache can resolve any of the missing nodes, which is only true for a node the cache has not seen yet as an enabled
      * member of the router's target node group. Any other missing node stays unresolved after a refresh, so refreshing would re-read every enabled node on
-     * EVERY data row (expensive!) for nothing.
+     * EVERY data row (expensive!) for nothing. A node the channel ignores or a grouplet excludes is unresolvable too, because rebuilding the available nodes
+     * re-applies those filters from caches that a node cache refresh does not touch, so this method must mirror the filters in findAvailableNodes.
      */
-    protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter) {
+    protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter, NodeChannel channel) {
         String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
         for (String missingNodeId : missingNodeIds) {
+            if (channel.isIgnoreEnabled(missingNodeId)) {
+                continue;
+            }
             Node missingNode = engine.getNodeService().findNode(missingNodeId);
             if (missingNode != null && missingNode.isSyncEnabled()
-                    && StringUtils.equals(targetNodeGroupId, missingNode.getNodeGroupId())) {
+                    && StringUtils.equals(targetNodeGroupId, missingNode.getNodeGroupId())
+                    && engine.getGroupletService().isTargetEnabled(triggerRouter, missingNode)) {
                 return true;
             }
         }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -804,6 +804,9 @@ public class RouterService extends AbstractService implements IRouterService, IN
      * EVERY data row (expensive!) for nothing.
      */
     protected boolean isNodeCacheRefreshNeeded(Collection<String> missingNodeIds, TriggerRouter triggerRouter) {
+        if (!missingNodeIds.isEmpty()) {
+            return true;
+        }
         String targetNodeGroupId = triggerRouter.getRouter().getNodeGroupLink().getTargetNodeGroupId();
         for (String missingNodeId : missingNodeIds) {
             Node missingNode = engine.getNodeService().findNode(missingNodeId);

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -244,6 +244,90 @@ public class RouterServiceTest {
     }
 
     @Test
+    public void testIsNodeCacheRefreshNeededWhenMissingNodeIsEnabledMemberOfTargetGroup() {
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
+        assertTrue(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+    }
+
+    @Test
+    public void testIsNodeCacheRefreshNotNeededWhenMissingNodeBelongsToAnotherGroup() {
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, OTHER_NODE_GROUP));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+    }
+
+    @Test
+    public void testIsNodeCacheRefreshNotNeededWhenMissingNodeDoesNotExist() {
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(null);
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+    }
+
+    @Test
+    public void testIsNodeCacheRefreshNotNeededWhenMissingNodeIsSyncDisabled() {
+        Node disabledNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
+        disabledNode.setSyncEnabled(false);
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(disabledNode);
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+    }
+
+    @Test
+    public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeBelongsToAnotherGroup() {
+        givenNodeGroupLinkToTargetGroup();
+        when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.emptyList());
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, OTHER_NODE_GROUP));
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
+        assertTrue(nodeIds.isEmpty());
+        verify(nodeService, never()).flushNodeGroupCache();
+        verify(nodeService, times(1)).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
+    }
+
+    @Test
+    public void testFindNodeIdsFromNodeListRefreshesCacheWhenTargetNodeIsMissingFromStaleCache() {
+        givenNodeGroupLinkToTargetGroup();
+        Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
+        when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.emptyList())
+                .thenReturn(Collections.singletonList(targetNode));
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(targetNode);
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
+        assertEquals(Arrays.asList(TARGET_NODE_ID), new ArrayList<String>(nodeIds));
+        verify(nodeService, times(1)).flushNodeGroupCache();
+        verify(nodeService, times(2)).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
+    }
+
+    @Test
+    public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenAllTargetNodesResolve() {
+        givenNodeGroupLinkToTargetGroup();
+        when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP))
+                .thenReturn(Collections.singletonList(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP)));
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
+        assertEquals(Arrays.asList(TARGET_NODE_ID), new ArrayList<String>(nodeIds));
+        verify(nodeService, never()).flushNodeGroupCache();
+        verify(nodeService, never()).findNode(TARGET_NODE_ID);
+    }
+
+    private void givenNodeGroupLinkToTargetGroup() {
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false))
+                .thenReturn(new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP));
+        when(groupletService.getTargetEnabled(any(TriggerRouter.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
+    }
+
+    @SuppressWarnings("deprecation")
+    private TriggerRouter newTriggerRouter() {
+        return new TriggerRouter(new Trigger("a", CHANNEL_2_TEST.getChannelId()),
+                new Router("test", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default"));
+    }
+
+    private Data newDataForNodeList() {
+        Data data = new Data();
+        data.setTableName("a");
+        data.setNodeList(TARGET_NODE_ID);
+        return data;
+    }
+
+    private ChannelRouterContext newContext() {
+        return new ChannelRouterContext(SOURCE_NODE_GROUP, new NodeChannel(CHANNEL_2_TEST), mock(ISqlTransaction.class), null);
+    }
+
+    @Test
     public void testGetDataRouterUsesRegisteredRouterForKnownType() {
         IDataRouter defaultRouter = mock(IDataRouter.class);
         Map<String, IDataRouter> routers = new HashMap<String, IDataRouter>();

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -96,6 +96,7 @@ public class RouterServiceTest {
         when(engine.getConfigurationService()).thenReturn(configurationService);
         when(engine.getNodeService()).thenReturn(nodeService);
         when(engine.getGroupletService()).thenReturn(groupletService);
+        when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(true);
         routerService = new RouterService(engine);
     }
 
@@ -246,19 +247,19 @@ public class RouterServiceTest {
     @Test
     public void testIsNodeCacheRefreshNeededWhenMissingNodeIsEnabledMemberOfTargetGroup() {
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
-        assertTrue(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+        assertTrue(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
     }
 
     @Test
     public void testIsNodeCacheRefreshNotNeededWhenMissingNodeBelongsToAnotherGroup() {
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, OTHER_NODE_GROUP));
-        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
     }
 
     @Test
     public void testIsNodeCacheRefreshNotNeededWhenMissingNodeDoesNotExist() {
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(null);
-        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
     }
 
     @Test
@@ -266,7 +267,23 @@ public class RouterServiceTest {
         Node disabledNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
         disabledNode.setSyncEnabled(false);
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(disabledNode);
-        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter()));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
+    }
+
+    @Test
+    public void testIsNodeCacheRefreshNotNeededWhenMissingNodeIsIgnoredOnChannel() {
+        NodeChannel channel = newChannel();
+        channel.setIgnoreEnabled(TARGET_NODE_ID, true);
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), channel));
+        verify(nodeService, never()).findNode(TARGET_NODE_ID);
+    }
+
+    @Test
+    public void testIsNodeCacheRefreshNotNeededWhenMissingNodeIsExcludedByGrouplet() {
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
+        when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(false);
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
     }
 
     @Test
@@ -304,6 +321,34 @@ public class RouterServiceTest {
         verify(nodeService, never()).findNode(TARGET_NODE_ID);
     }
 
+    @Test
+    public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeIsIgnoredOnChannel() {
+        givenNodeGroupLinkToTargetGroup();
+        Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
+        NodeChannel channel = newChannel();
+        channel.setIgnoreEnabled(TARGET_NODE_ID, true);
+        when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.singletonList(targetNode));
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(targetNode);
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext(channel));
+        assertTrue(nodeIds.isEmpty());
+        verify(nodeService, never()).flushNodeGroupCache();
+        verify(nodeService, times(1)).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
+    }
+
+    @Test
+    public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeIsExcludedByGrouplet() {
+        givenNodeGroupLinkToTargetGroup();
+        Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
+        when(groupletService.getTargetEnabled(any(TriggerRouter.class), any())).thenReturn(Collections.emptySet());
+        when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(false);
+        when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.singletonList(targetNode));
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(targetNode);
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
+        assertTrue(nodeIds.isEmpty());
+        verify(nodeService, never()).flushNodeGroupCache();
+        verify(nodeService, times(1)).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
+    }
+
     private void givenNodeGroupLinkToTargetGroup() {
         when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false))
                 .thenReturn(new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP));
@@ -323,8 +368,16 @@ public class RouterServiceTest {
         return data;
     }
 
+    private NodeChannel newChannel() {
+        return new NodeChannel(CHANNEL_2_TEST);
+    }
+
     private ChannelRouterContext newContext() {
-        return new ChannelRouterContext(SOURCE_NODE_GROUP, new NodeChannel(CHANNEL_2_TEST), mock(ISqlTransaction.class), null);
+        return newContext(newChannel());
+    }
+
+    private ChannelRouterContext newContext(NodeChannel channel) {
+        return new ChannelRouterContext(SOURCE_NODE_GROUP, channel, mock(ISqlTransaction.class), null);
     }
 
     @Test

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -88,6 +88,7 @@ public class RouterServiceTest {
         nodeService = mock(INodeService.class);
         groupletService = mock(IGroupletService.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        when(parameterService.getTablePrefix()).thenReturn("sym");
         when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
         when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
         when(engine.getParameterService()).thenReturn(parameterService);
@@ -96,6 +97,9 @@ public class RouterServiceTest {
         when(engine.getConfigurationService()).thenReturn(configurationService);
         when(engine.getNodeService()).thenReturn(nodeService);
         when(engine.getGroupletService()).thenReturn(groupletService);
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false))
+                .thenReturn(new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP));
+        when(groupletService.getTargetEnabled(any(TriggerRouter.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
         when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(true);
         routerService = new RouterService(engine);
     }
@@ -280,6 +284,14 @@ public class RouterServiceTest {
     }
 
     @Test
+    public void testIsNodeCacheRefreshNotNeededWhenRouterHasNoNodeGroupLink() {
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(null);
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
+        assertFalse(routerService.isNodeCacheRefreshNeeded(Arrays.asList(TARGET_NODE_ID), newTriggerRouter(), newChannel()));
+        verify(nodeService, never()).findNode(TARGET_NODE_ID);
+    }
+
+    @Test
     public void testIsNodeCacheRefreshNotNeededWhenMissingNodeIsExcludedByGrouplet() {
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
         when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(false);
@@ -288,7 +300,6 @@ public class RouterServiceTest {
 
     @Test
     public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeBelongsToAnotherGroup() {
-        givenNodeGroupLinkToTargetGroup();
         when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.emptyList());
         when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, OTHER_NODE_GROUP));
         Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
@@ -299,7 +310,6 @@ public class RouterServiceTest {
 
     @Test
     public void testFindNodeIdsFromNodeListRefreshesCacheWhenTargetNodeIsMissingFromStaleCache() {
-        givenNodeGroupLinkToTargetGroup();
         Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
         when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP)).thenReturn(Collections.emptyList())
                 .thenReturn(Collections.singletonList(targetNode));
@@ -312,7 +322,6 @@ public class RouterServiceTest {
 
     @Test
     public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenAllTargetNodesResolve() {
-        givenNodeGroupLinkToTargetGroup();
         when(nodeService.findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP))
                 .thenReturn(Collections.singletonList(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP)));
         Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
@@ -323,7 +332,6 @@ public class RouterServiceTest {
 
     @Test
     public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeIsIgnoredOnChannel() {
-        givenNodeGroupLinkToTargetGroup();
         Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
         NodeChannel channel = newChannel();
         channel.setIgnoreEnabled(TARGET_NODE_ID, true);
@@ -336,8 +344,17 @@ public class RouterServiceTest {
     }
 
     @Test
+    public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenRouterHasNoNodeGroupLink() {
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(null);
+        when(nodeService.findNode(TARGET_NODE_ID)).thenReturn(new Node(TARGET_NODE_ID, TARGET_NODE_GROUP));
+        Collection<String> nodeIds = routerService.findNodeIdsFromNodeList(newDataForNodeList(), newTriggerRouter(), newContext());
+        assertTrue(nodeIds.isEmpty());
+        verify(nodeService, never()).flushNodeGroupCache();
+        verify(nodeService, never()).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
+    }
+
+    @Test
     public void testFindNodeIdsFromNodeListSkipsCacheRefreshWhenTargetNodeIsExcludedByGrouplet() {
-        givenNodeGroupLinkToTargetGroup();
         Node targetNode = new Node(TARGET_NODE_ID, TARGET_NODE_GROUP);
         when(groupletService.getTargetEnabled(any(TriggerRouter.class), any())).thenReturn(Collections.emptySet());
         when(groupletService.isTargetEnabled(any(TriggerRouter.class), any(Node.class))).thenReturn(false);
@@ -347,12 +364,6 @@ public class RouterServiceTest {
         assertTrue(nodeIds.isEmpty());
         verify(nodeService, never()).flushNodeGroupCache();
         verify(nodeService, times(1)).findEnabledNodesFromNodeGroup(TARGET_NODE_GROUP);
-    }
-
-    private void givenNodeGroupLinkToTargetGroup() {
-        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false))
-                .thenReturn(new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP));
-        when(groupletService.getTargetEnabled(any(TriggerRouter.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
     }
 
     @SuppressWarnings("deprecation")

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -24,10 +24,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,19 +43,24 @@ import java.util.Set;
 
 import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.model.Channel;
 import org.jumpmind.symmetric.model.Data;
 import org.jumpmind.symmetric.model.Node;
+import org.jumpmind.symmetric.model.NodeChannel;
 import org.jumpmind.symmetric.model.NodeGroupLink;
 import org.jumpmind.symmetric.model.Router;
 import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.model.TriggerRouter;
+import org.jumpmind.symmetric.route.ChannelRouterContext;
 import org.jumpmind.symmetric.route.IDataRouter;
 import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IExtensionService;
+import org.jumpmind.symmetric.service.IGroupletService;
+import org.jumpmind.symmetric.service.INodeService;
 import org.jumpmind.symmetric.service.IParameterService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,9 +69,13 @@ public class RouterServiceTest {
     final static Channel CHANNEL_2_TEST = new Channel("test", 1);
     final static String SOURCE_NODE_GROUP = "source";
     final static String TARGET_NODE_GROUP = "target";
+    final static String OTHER_NODE_GROUP = "other";
+    final static String TARGET_NODE_ID = "node1";
     RouterService routerService;
     IConfigurationService configurationService;
     IExtensionService extensionService;
+    INodeService nodeService;
+    IGroupletService groupletService;
 
     @BeforeEach
     public void setup() {
@@ -69,6 +85,8 @@ public class RouterServiceTest {
         IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
         extensionService = mock(IExtensionService.class);
         configurationService = mock(IConfigurationService.class);
+        nodeService = mock(INodeService.class);
+        groupletService = mock(IGroupletService.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
         when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
@@ -76,6 +94,8 @@ public class RouterServiceTest {
         when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
         when(engine.getExtensionService()).thenReturn(extensionService);
         when(engine.getConfigurationService()).thenReturn(configurationService);
+        when(engine.getNodeService()).thenReturn(nodeService);
+        when(engine.getGroupletService()).thenReturn(groupletService);
         routerService = new RouterService(engine);
     }
 


### PR DESCRIPTION
Routing job runs table scan on sym_node for each data record, when there are no nodes in list (node has syn_enabled=false, node is in another tier, node no longer exists)

Also:
* NodeCache.getNodesByGroup() reloads all enabled nodes on any miss, and flushNodeGroupCache() invalidated EVERY group rather than the one that missed.

* A node that is enabled and in the target group but excluded by a channel ignore or grouplet would refresh/run query per row being routed. 

 
