### PR TITLE
SYM-7916: continue past DDL that fails only because the object already exists

### DIFF
--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -423,6 +423,19 @@ db.sql.query.timeout.seconds=3600
 # Tags: database
 db.jdbc.isolation.level=
 
+# Continue past a DDL statement that failed only because the object it creates already exists, instead of failing
+# the batch carrying it.  Table definitions travel on the same channel as change data, so a redundant CREATE INDEX
+# or CREATE TABLE stops every batch queued behind it and halts replication for that table -- even though the only
+# possible effect of the statement succeeding would have been to create something that was already there.  The
+# skipped statement is logged at WARN with the driver's message.  Set to false to restore the previous behavior of
+# failing the batch, in which case note that retrying re-issues the same DDL and fails identically, so the batch
+# has to be ignored rather than have its error cleared.
+#
+# DatabaseOverridable: true
+# Tags: database
+# Type: boolean
+db.tolerate.object.already.exists.on.ddl=true
+
 # If set to true forces database columns that contain character data to be read as bytes (bypassing JDBC driver character encoding) 
 # so the raw values be encoded using the system default character set (usually UTF8).  This property was added to bypass MySQL character
 # encoding so the raw data can be converted to utf8 directly.

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -431,7 +431,10 @@ db.jdbc.isolation.level=
 # failing the batch, in which case note that retrying re-issues the same DDL and fails identically, so the batch
 # has to be ignored rather than have its error cleared.
 #
-# DatabaseOverridable: true
+# Read through SqlTemplateSettings, which is built once at startup from the properties file, so unlike most parameters
+# this one is not overridable from sym_parameter and a change needs a restart.  Its neighbours in this block that are
+# read the same way (db.jdbc.isolation.level, db.read.strings.as.bytes) likewise declare no DatabaseOverridable.
+#
 # Tags: database
 # Type: boolean
 db.tolerate.object.already.exists.on.ddl=true

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -431,6 +431,11 @@ db.jdbc.isolation.level=
 # failing the batch, in which case note that retrying re-issues the same DDL and fails identically, so the batch
 # has to be ignored rather than have its error cleared.
 #
+# Defaulted on deliberately, after narrowing which messages qualify (see objectAlreadyExistsMessageParts in
+# JdbcSqlTemplate). The two message fragments that could plausibly mean something other than "this exact object
+# is already there" (MySQL's duplicate key/column name messages) were removed during review; everything left is
+# an unambiguous statement of existence, so tolerating it does not risk masking real schema drift.
+#
 # Read through SqlTemplateSettings, which is built once at startup from the properties file, so unlike most parameters
 # this one is not overridable from sym_parameter and a change needs a restart.  Its neighbours in this block that are
 # read the same way (db.jdbc.isolation.level, db.read.strings.as.bytes) likewise declare no DatabaseOverridable.

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/SqlConstants.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/SqlConstants.java
@@ -28,4 +28,6 @@ abstract public class SqlConstants {
     public static final int DEFAULT_STREAMING_FETCH_SIZE = 1000;
     public static final StringMapper STRING_MAPPER = new StringMapper();
     public static final String POSTGRES_CONVERT_INFINITY_DATE_TO_NULL = "postgres.convert.infinity.date.to.null";
+    /** See the parameter of the same name: continue past a DDL statement that failed only because the object already exists. */
+    public static final String TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL = "db.tolerate.object.already.exists.on.ddl";
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -90,6 +90,15 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
     protected String[] dataTruncationStates;
     protected int[] objectAlreadyExistsCodes;
     protected String[] objectAlreadyExistsStates;
+    /**
+     * Cross-vendor message fragments identifying an "object already exists" failure, matched case-insensitively. Error codes cannot be shared defaults, since
+     * the same number means different things on different vendors, and only PostgreSQL populates the SQLSTATE list today. These cover platforms whose DDL
+     * builders live outside this repository -- SQL Server 1913 ("an index or statistics with name 'x' already exists"), Oracle ORA-00955 ("name is already used
+     * by an existing object"), MySQL ("Duplicate key name") -- so they get the tolerance with no per-platform change. Server-localized messages defeat message
+     * matching, so a platform that depends on this should still populate {@link #objectAlreadyExistsCodes}.
+     */
+    protected String[] objectAlreadyExistsMessageParts = { "already exists", "already an object named",
+            "is already used by an existing object", "duplicate key name", "duplicate column name" };
     protected int[] objectDoesNotExistCodes;
     protected String[] objectDoesNotExistStates;
     protected int isolationLevel;
@@ -478,15 +487,31 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                                     con.commit();
                                 }
                             } catch (SQLException ex) {
-                                boolean isDrop = statement.toLowerCase().trim().startsWith("drop");
-                                boolean isSequenceCreate = statement.toLowerCase().trim().startsWith("create sequence");
+                                String trimmed = statement.toLowerCase().trim();
+                                boolean isDrop = trimmed.startsWith("drop");
+                                boolean isSequenceCreate = trimmed.startsWith("create sequence");
+                                boolean isCreateOrAlter = trimmed.startsWith("create") || trimmed.startsWith("alter");
                                 if (resultsListener != null) {
                                     resultsListener.sqlErrored(statement, translate(statement, ex), statementCount, isDrop, isSequenceCreate);
                                 }
                                 if ((isDrop && !failOnDrops) || (isSequenceCreate && !failOnSequenceCreate)) {
                                     log.debug("{}.  Failed to execute: {}", ex.getMessage(), statement);
+                                } else if (isCreateOrAlter && isTolerateObjectAlreadyExists() && doesObjectAlreadyExist(ex)) {
+                                    /*
+                                     * Re-sending a table definition to a target where the object already exists is a no-op that used to fail the batch. Because
+                                     * table definitions ride the same channel as change data, one such statement stopped every batch queued behind it and all
+                                     * replication for that table with it, while the only possible effect of the statement succeeding was to create something
+                                     * that was already there.
+                                     */
+                                    log.warn("Object already exists, continuing.  Failed to execute: {} ({})", statement, ex.getMessage());
                                 } else {
                                     log.warn("{}.  Failed to execute: {}", ex.getMessage(), statement);
+                                    if (isCreateOrAlter && doesObjectAlreadyExist(ex)) {
+                                        // Retrying re-issues the same DDL and fails identically, so Clear Error cannot help here.
+                                        log.warn("The statement above failed because the object already exists, so this batch will fail the same way on "
+                                                + "every retry.  Ignore the batch rather than clearing its error, or set {}=true to continue past this "
+                                                + "condition automatically.", SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL);
+                                    }
                                     if (failOnError) {
                                         throw ex;
                                     }
@@ -1129,10 +1154,19 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
         return truncation;
     }
 
+    /**
+     * Whether a DDL statement that failed only because the object already exists should be logged and stepped over instead of failing the script. Defaults to
+     * true: the statement is a no-op either way, and failing it stops every batch queued behind it on the same channel.
+     */
+    protected boolean isTolerateObjectAlreadyExists() {
+        return settings == null || settings.getProperties() == null
+                || settings.getProperties().is(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, true);
+    }
+
     @Override
     public boolean doesObjectAlreadyExist(Throwable ex) {
         boolean alreadyExists = false;
-        if (objectAlreadyExistsCodes != null || objectAlreadyExistsStates != null) {
+        if (objectAlreadyExistsCodes != null || objectAlreadyExistsStates != null || objectAlreadyExistsMessageParts != null) {
             SQLException sqlEx = findSQLException(ex);
             if (sqlEx != null) {
                 if (objectAlreadyExistsCodes != null) {
@@ -1149,6 +1183,18 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                     if (sqlState != null) {
                         for (String objectAlreadyExistsState : objectAlreadyExistsStates) {
                             if (sqlState.equals(objectAlreadyExistsState)) {
+                                alreadyExists = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (!alreadyExists && objectAlreadyExistsMessageParts != null) {
+                    String sqlMessage = sqlEx.getMessage();
+                    if (sqlMessage != null) {
+                        sqlMessage = sqlMessage.toLowerCase();
+                        for (String objectAlreadyExistsMessagePart : objectAlreadyExistsMessageParts) {
+                            if (objectAlreadyExistsMessagePart != null && sqlMessage.contains(objectAlreadyExistsMessagePart.toLowerCase())) {
                                 alreadyExists = true;
                                 break;
                             }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -494,9 +494,10 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                                 if (resultsListener != null) {
                                     resultsListener.sqlErrored(statement, translate(statement, ex), statementCount, isDrop, isSequenceCreate);
                                 }
+                                boolean objectAlreadyExists = isCreateOrAlter && doesObjectAlreadyExist(ex);
                                 if ((isDrop && !failOnDrops) || (isSequenceCreate && !failOnSequenceCreate)) {
                                     log.debug("{}.  Failed to execute: {}", ex.getMessage(), statement);
-                                } else if (isCreateOrAlter && isTolerateObjectAlreadyExists() && doesObjectAlreadyExist(ex)) {
+                                } else if (objectAlreadyExists && isTolerateObjectAlreadyExists()) {
                                     /*
                                      * Re-sending a table definition to a target where the object already exists is a no-op that used to fail the batch. Because
                                      * table definitions ride the same channel as change data, one such statement stopped every batch queued behind it and all
@@ -506,7 +507,7 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                                     log.warn("Object already exists, continuing.  Failed to execute: {} ({})", statement, ex.getMessage());
                                 } else {
                                     log.warn("{}.  Failed to execute: {}", ex.getMessage(), statement);
-                                    if (isCreateOrAlter && doesObjectAlreadyExist(ex)) {
+                                    if (objectAlreadyExists) {
                                         // Retrying re-issues the same DDL and fails identically, so Clear Error cannot help here.
                                         log.warn("The statement above failed because the object already exists, so this batch will fail the same way on "
                                                 + "every retry.  Ignore the batch rather than clearing its error, or set {}=true to continue past this "

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -94,11 +94,17 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
      * Cross-vendor message fragments identifying an "object already exists" failure, matched case-insensitively. Error codes cannot be shared defaults, since
      * the same number means different things on different vendors, and only PostgreSQL populates the SQLSTATE list today. These cover platforms whose DDL
      * builders live outside this repository -- SQL Server 1913 ("an index or statistics with name 'x' already exists"), Oracle ORA-00955 ("name is already used
-     * by an existing object"), MySQL ("Duplicate key name") -- so they get the tolerance with no per-platform change. Server-localized messages defeat message
-     * matching, so a platform that depends on this should still populate {@link #objectAlreadyExistsCodes}.
+     * by an existing object") -- so they get the tolerance with no per-platform change. Server-localized messages defeat message matching, so a platform that
+     * depends on this should still populate {@link #objectAlreadyExistsCodes}.
+     * <p>
+     * Deliberately does NOT include MySQL's "Duplicate key name". That message is unambiguous on its own, but the only case that reaches it in practice is
+     * {@code MySqlDdlReader.isInternalForeignKeyIndex} stripping an FK-backing index out of the read-back model, which then diffs as missing and gets
+     * re-emitted. That is a real defect, but the honest fix is on the emission side (stop generating the DDL, the way {@code MySqlDdlBuilder} already skips
+     * dropping that same index via {@code ForeignKey.isAutoIndexPresent()}), not swallowing the resulting failure here. Also does NOT include "Duplicate column
+     * name": conceded during review as a materially better candidate for genuine schema drift than a duplicate index name is, and it was never tested.
      */
     protected String[] objectAlreadyExistsMessageParts = { "already exists", "already an object named",
-            "is already used by an existing object", "duplicate key name", "duplicate column name" };
+            "is already used by an existing object" };
     protected int[] objectDoesNotExistCodes;
     protected String[] objectDoesNotExistStates;
     protected int isolationLevel;

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsIntegrationTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsIntegrationTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.platform.JdbcDatabasePlatformFactory;
+import org.jumpmind.properties.TypedProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * SYM-7916, end to end. {@link JdbcSqlTemplateObjectExistsTest} covers {@code doesObjectAlreadyExist} and {@code isTolerateObjectAlreadyExists} in isolation;
+ * this drives a real duplicate-object failure through {@link JdbcSqlTemplate#execute} itself, the branch neither of those unit tests reaches, against a real H2
+ * database rather than a mock. Same pattern as {@link SqlScriptTest}.
+ */
+public class JdbcSqlTemplateObjectExistsIntegrationTest {
+    private SingleConnectionDataSource ds;
+
+    @AfterEach
+    void tearDown() {
+        if (ds != null) {
+            ds.destroy();
+        }
+    }
+
+    @Test
+    void toleratedByDefaultTheDuplicateCreateIsSkippedAndTheScriptCompletes() throws Exception {
+        IDatabasePlatform platform = platform("jstoleron");
+        // H2's own duplicate-table message ("Table \"T\" already exists") is exactly the generic fragment
+        // this classifier matches, so this exercises the real driver's wording, not a fabricated one.
+        new SqlScript("CREATE TABLE t (id int);\nCREATE TABLE t (id int);\n", platform.getSqlTemplate(), true, null).execute();
+        assertEquals(0, new JdbcTemplate(ds).queryForObject("select count(*) from t", Integer.class));
+    }
+
+    @Test
+    void withToleranceOffTheDuplicateCreateStillFailsTheScript() throws Exception {
+        IDatabasePlatform platform = platform("jstoleroff");
+        TypedProperties properties = new TypedProperties();
+        properties.put(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, "false");
+        ((JdbcSqlTemplate) platform.getSqlTemplate()).getSettings().setProperties(properties);
+        SqlScript script = new SqlScript("CREATE TABLE t (id int);\nCREATE TABLE t (id int);\n", platform.getSqlTemplate(), true, null);
+        assertThrows(Exception.class, script::execute,
+                "restoring the pre-SYM-7916 behavior (parameter off) must still fail the batch on a duplicate create");
+    }
+
+    @Test
+    void toleranceNeverMasksAnUnrelatedFailure() throws Exception {
+        IDatabasePlatform platform = platform("jsunrelated");
+        // Tolerance is on (default); a syntax error must still fail the script. This is the case Pavel's
+        // review was protecting: the tolerance must never become a general "ignore DDL errors" switch.
+        SqlScript script = new SqlScript("CREATE TALBE typo (id int);\n", platform.getSqlTemplate(), true, null);
+        assertThrows(Exception.class, script::execute, "a genuine SQL error must not be swallowed by the tolerance");
+    }
+
+    private IDatabasePlatform platform(String dbName) throws Exception {
+        Class.forName("org.h2.Driver");
+        Connection c = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1");
+        ds = new SingleConnectionDataSource(c, true);
+        return JdbcDatabasePlatformFactory.getInstance().create(ds, new SqlTemplateSettings(), true, false);
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
@@ -1,0 +1,116 @@
+package org.jumpmind.db.sql;
+
+import java.sql.SQLException;
+
+import org.jumpmind.db.platform.DatabaseInfo;
+import org.jumpmind.properties.TypedProperties;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SYM-7916. Classification of "object already exists" DDL failures.
+ * <p>
+ * The reach of the fix rests entirely on these message fragments for platforms whose DDL builders are not in this repository (SQL Server, Oracle), so the exact
+ * vendor wording is pinned here. Error codes are per-platform and cannot be shared defaults, since the same number means different things on different vendors.
+ */
+class JdbcSqlTemplateObjectExistsTest {
+    /** Concrete subclass so the classification logic can be exercised with no DataSource and no database. */
+    private static class TestTemplate extends JdbcSqlTemplate {
+        TestTemplate() {
+            super(null, new SqlTemplateSettings(), null, new DatabaseInfo());
+        }
+
+        void withProperty(String key, String value) {
+            TypedProperties properties = new TypedProperties();
+            properties.put(key, value);
+            settings.setProperties(properties);
+        }
+
+        void withErrorCodes(int... codes) {
+            objectAlreadyExistsCodes = codes;
+        }
+    }
+
+    private static SQLException sqlException(String message, String sqlState, int errorCode) {
+        return new SQLException(message, sqlState, errorCode);
+    }
+
+    @Test
+    void sqlServerIndexAlreadyExistsIsRecognised() {
+        // The exact message behind SQL Server error 1913, which is what stalled replication at the reporting site.
+        SQLException ex = sqlException(
+                "The operation failed because an index or statistics with name 'f0101_12' already exists on table 'DB.dbo.f0101'.",
+                "S0001", 1913);
+        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(ex));
+    }
+
+    @Test
+    void sqlServerTableAlreadyExistsIsRecognised() {
+        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
+                sqlException("There is already an object named 'f42119' in the database.", "S0001", 2714)));
+    }
+
+    @Test
+    void oracleNameAlreadyUsedIsRecognised() {
+        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
+                sqlException("ORA-00955: name is already used by an existing object", "42000", 955)));
+    }
+
+    @Test
+    void mysqlDuplicateKeyNameIsRecognised() {
+        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
+                sqlException("Duplicate key name 'f42119_18'", "42000", 1061)));
+    }
+
+    @Test
+    void matchingIsCaseInsensitive() {
+        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
+                sqlException("INDEX ALREADY EXISTS", "S0001", 1913)));
+    }
+
+    @Test
+    void anUnrelatedFailureIsNotClassifiedAsAlreadyExisting() {
+        // The tolerance must not swallow a genuine problem such as a constraint violation or a missing object.
+        TestTemplate template = new TestTemplate();
+        Assert.assertFalse(template.doesObjectAlreadyExist(
+                sqlException("Violation of PRIMARY KEY constraint 'PK_f42119'. Cannot insert duplicate key.", "23000", 2627)));
+        Assert.assertFalse(template.doesObjectAlreadyExist(
+                sqlException("Invalid object name 'dbo.f42119'.", "S0002", 208)));
+        Assert.assertFalse(template.doesObjectAlreadyExist(
+                sqlException("Timeout expired", "HYT00", 0)));
+    }
+
+    @Test
+    void aPlatformErrorCodeStillMatchesWithoutAMessageMatch() {
+        // Server-localized messages defeat message matching, which is why a platform that depends on this should
+        // populate the error-code list as well.
+        TestTemplate template = new TestTemplate();
+        template.withErrorCodes(1913);
+        Assert.assertTrue(template.doesObjectAlreadyExist(
+                sqlException("Die Operation ist fehlgeschlagen: Index vorhanden", "S0001", 1913)));
+    }
+
+    @Test
+    void nonSqlExceptionsAreNotClassified() {
+        Assert.assertFalse(new TestTemplate().doesObjectAlreadyExist(new RuntimeException("already exists")));
+    }
+
+    @Test
+    void toleranceIsOnByDefault() {
+        Assert.assertTrue(new TestTemplate().isTolerateObjectAlreadyExists());
+    }
+
+    @Test
+    void toleranceCanBeTurnedOffByParameter() {
+        TestTemplate template = new TestTemplate();
+        template.withProperty(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, "false");
+        Assert.assertFalse(template.isTolerateObjectAlreadyExists());
+    }
+
+    @Test
+    void toleranceStaysOnWhenTheParameterIsSetToTrue() {
+        TestTemplate template = new TestTemplate();
+        template.withProperty(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, "true");
+        Assert.assertTrue(template.isTolerateObjectAlreadyExists());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
@@ -1,11 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jumpmind.db.sql;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
 import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.properties.TypedProperties;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * SYM-7916. Classification of "object already exists" DDL failures.
@@ -14,103 +38,66 @@ import org.junit.jupiter.api.Test;
  * vendor wording is pinned here. Error codes are per-platform and cannot be shared defaults, since the same number means different things on different vendors.
  */
 class JdbcSqlTemplateObjectExistsTest {
-    /** Concrete subclass so the classification logic can be exercised with no DataSource and no database. */
-    private static class TestTemplate extends JdbcSqlTemplate {
-        TestTemplate() {
-            super(null, new SqlTemplateSettings(), null, new DatabaseInfo());
-        }
-
-        void withProperty(String key, String value) {
-            TypedProperties properties = new TypedProperties();
-            properties.put(key, value);
-            settings.setProperties(properties);
-        }
-
-        void withErrorCodes(int... codes) {
-            objectAlreadyExistsCodes = codes;
-        }
+    private JdbcSqlTemplate template() {
+        return new JdbcSqlTemplate(null, new SqlTemplateSettings(), null, new DatabaseInfo());
     }
 
     private static SQLException sqlException(String message, String sqlState, int errorCode) {
         return new SQLException(message, sqlState, errorCode);
     }
 
-    @Test
-    void sqlServerIndexAlreadyExistsIsRecognised() {
-        // The exact message behind SQL Server error 1913, which is what stalled replication at the reporting site.
-        SQLException ex = sqlException(
-                "The operation failed because an index or statistics with name 'f0101_12' already exists on table 'DB.dbo.f0101'.",
-                "S0001", 1913);
-        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(ex));
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(
+            delimiter = '|',
+            value = {
+                    "SQL Server 1913 index    | The operation failed because an index or statistics with name 'f0101_12' already exists on table 'DB.dbo.f0101'. | S0001 | 1913",
+                    "SQL Server 2714 table    | There is already an object named 'f42119' in the database.                                                       | S0001 | 2714",
+                    "Oracle ORA-00955         | ORA-00955: name is already used by an existing object                                                            | 42000 |  955",
+                    "MySQL duplicate key name | Duplicate key name 'f42119_18'                                                                                   | 42000 | 1061",
+                    "case insensitive         | INDEX ALREADY EXISTS                                                                                             | S0001 | 1913",
+            })
+    void vendorAlreadyExistsMessagesAreRecognised(String label, String message, String sqlState, int errorCode) {
+        assertTrue(template().doesObjectAlreadyExist(sqlException(message, sqlState, errorCode)), label);
     }
 
-    @Test
-    void sqlServerTableAlreadyExistsIsRecognised() {
-        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
-                sqlException("There is already an object named 'f42119' in the database.", "S0001", 2714)));
-    }
-
-    @Test
-    void oracleNameAlreadyUsedIsRecognised() {
-        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
-                sqlException("ORA-00955: name is already used by an existing object", "42000", 955)));
-    }
-
-    @Test
-    void mysqlDuplicateKeyNameIsRecognised() {
-        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
-                sqlException("Duplicate key name 'f42119_18'", "42000", 1061)));
-    }
-
-    @Test
-    void matchingIsCaseInsensitive() {
-        Assert.assertTrue(new TestTemplate().doesObjectAlreadyExist(
-                sqlException("INDEX ALREADY EXISTS", "S0001", 1913)));
-    }
-
-    @Test
-    void anUnrelatedFailureIsNotClassifiedAsAlreadyExisting() {
-        // The tolerance must not swallow a genuine problem such as a constraint violation or a missing object.
-        TestTemplate template = new TestTemplate();
-        Assert.assertFalse(template.doesObjectAlreadyExist(
-                sqlException("Violation of PRIMARY KEY constraint 'PK_f42119'. Cannot insert duplicate key.", "23000", 2627)));
-        Assert.assertFalse(template.doesObjectAlreadyExist(
-                sqlException("Invalid object name 'dbo.f42119'.", "S0002", 208)));
-        Assert.assertFalse(template.doesObjectAlreadyExist(
-                sqlException("Timeout expired", "HYT00", 0)));
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(
+            delimiter = '|',
+            value = {
+                    "primary key violation | Violation of PRIMARY KEY constraint 'PK_f42119'. Cannot insert duplicate key. | 23000 | 2627",
+                    "missing object        | Invalid object name 'dbo.f42119'.                                            | S0002 |  208",
+                    "timeout               | Timeout expired                                                              | HYT00 |    0",
+            })
+    void unrelatedFailuresAreNotClassifiedAsAlreadyExisting(String label, String message, String sqlState, int errorCode) {
+        // The tolerance must not swallow a genuine problem.
+        assertFalse(template().doesObjectAlreadyExist(sqlException(message, sqlState, errorCode)), label);
     }
 
     @Test
     void aPlatformErrorCodeStillMatchesWithoutAMessageMatch() {
         // Server-localized messages defeat message matching, which is why a platform that depends on this should
         // populate the error-code list as well.
-        TestTemplate template = new TestTemplate();
-        template.withErrorCodes(1913);
-        Assert.assertTrue(template.doesObjectAlreadyExist(
+        JdbcSqlTemplate template = template();
+        template.objectAlreadyExistsCodes = new int[] { 1913 };
+        assertTrue(template.doesObjectAlreadyExist(
                 sqlException("Die Operation ist fehlgeschlagen: Index vorhanden", "S0001", 1913)));
     }
 
     @Test
     void nonSqlExceptionsAreNotClassified() {
-        Assert.assertFalse(new TestTemplate().doesObjectAlreadyExist(new RuntimeException("already exists")));
+        assertFalse(template().doesObjectAlreadyExist(new RuntimeException("already exists")));
     }
 
-    @Test
-    void toleranceIsOnByDefault() {
-        Assert.assertTrue(new TestTemplate().isTolerateObjectAlreadyExists());
-    }
-
-    @Test
-    void toleranceCanBeTurnedOffByParameter() {
-        TestTemplate template = new TestTemplate();
-        template.withProperty(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, "false");
-        Assert.assertFalse(template.isTolerateObjectAlreadyExists());
-    }
-
-    @Test
-    void toleranceStaysOnWhenTheParameterIsSetToTrue() {
-        TestTemplate template = new TestTemplate();
-        template.withProperty(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, "true");
-        Assert.assertTrue(template.isTolerateObjectAlreadyExists());
+    @ParameterizedTest(name = "property={0} -> tolerate={1}")
+    @CsvSource({ ", true", "true, true", "false, false" })
+    void toleranceDefaultsOnAndIsControlledByTheParameter(String value, boolean expected) {
+        JdbcSqlTemplate template = template();
+        if (value != null) {
+            TypedProperties properties = new TypedProperties();
+            properties.put(SqlConstants.TOLERATE_OBJECT_ALREADY_EXISTS_ON_DDL, value);
+            template.getSettings().setProperties(properties);
+        }
+        assertTrue(expected == template.isTolerateObjectAlreadyExists(),
+                "value=" + value + " expected tolerate=" + expected);
     }
 }

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/sql/JdbcSqlTemplateObjectExistsTest.java
@@ -36,6 +36,12 @@ import org.junit.jupiter.params.provider.CsvSource;
  * <p>
  * The reach of the fix rests entirely on these message fragments for platforms whose DDL builders are not in this repository (SQL Server, Oracle), so the exact
  * vendor wording is pinned here. Error codes are per-platform and cannot be shared defaults, since the same number means different things on different vendors.
+ * <p>
+ * MySQL's "Duplicate key name" and "Duplicate column name" are deliberately NOT recognised, and {@link #mysqlDuplicateMessagesAreNoLongerTolerated()} pins
+ * that. The only case that reaches "Duplicate key name" in practice is {@code MySqlDdlReader.isInternalForeignKeyIndex} stripping an FK-backing index from the
+ * read-back model, which then diffs as missing and gets re-emitted -- a real defect, but the honest fix is on the emission side, not swallowing the failure
+ * here. "Duplicate column name" was never tested and is a materially better candidate for genuine schema drift than a duplicate index name is; tolerating it
+ * risks exactly what review flagged, hiding a real problem one batch later.
  */
 class JdbcSqlTemplateObjectExistsTest {
     private JdbcSqlTemplate template() {
@@ -53,7 +59,6 @@ class JdbcSqlTemplateObjectExistsTest {
                     "SQL Server 1913 index    | The operation failed because an index or statistics with name 'f0101_12' already exists on table 'DB.dbo.f0101'. | S0001 | 1913",
                     "SQL Server 2714 table    | There is already an object named 'f42119' in the database.                                                       | S0001 | 2714",
                     "Oracle ORA-00955         | ORA-00955: name is already used by an existing object                                                            | 42000 |  955",
-                    "MySQL duplicate key name | Duplicate key name 'f42119_18'                                                                                   | 42000 | 1061",
                     "case insensitive         | INDEX ALREADY EXISTS                                                                                             | S0001 | 1913",
             })
     void vendorAlreadyExistsMessagesAreRecognised(String label, String message, String sqlState, int errorCode) {
@@ -70,6 +75,20 @@ class JdbcSqlTemplateObjectExistsTest {
             })
     void unrelatedFailuresAreNotClassifiedAsAlreadyExisting(String label, String message, String sqlState, int errorCode) {
         // The tolerance must not swallow a genuine problem.
+        assertFalse(template().doesObjectAlreadyExist(sqlException(message, sqlState, errorCode)), label);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(
+            delimiter = '|',
+            value = {
+                    "MySQL duplicate key name    | Duplicate key name 'f42119_18'    | 42000 | 1061",
+                    "MySQL duplicate column name | Duplicate column name 'item_name' | 42000 | 1060",
+            })
+    void mysqlDuplicateMessagesAreNoLongerTolerated(String label, String message, String sqlState, int errorCode) {
+        // Narrowed during review: "duplicate key name" only ever covers MySqlDdlReader stripping an FK-backing
+        // index from the read-back model, which deserves an emission-side fix rather than living in this
+        // tolerance list, and "duplicate column name" is a materially better candidate for genuine drift.
         assertFalse(template().doesObjectAlreadyExist(sqlException(message, sqlState, errorCode)), label);
     }
 


### PR DESCRIPTION
Fixes [SYM-7916](https://jumpmind.atlassian.net/browse/SYM-7916).

## The problem

Re-sending a table definition to a target where the load already created the objects raises "already exists" (SQL Server 1913, Oracle ORA-00955, MySQL duplicate key name) and fails the batch carrying it. Table definitions ride the **same channel as change data**, so one failed batch holds every batch queued behind it and all replication for that table stops — while the only possible effect of the statement succeeding would have been to create something that was already there.

Observed six times across five dates and three engines at one site. Recovery also required non-obvious operator knowledge: retrying re-issues the same DDL and fails identically, so the batch has to be **ignored** rather than have its error cleared, and nothing said so.

## Why loader tolerance rather than guarded CREATE INDEX

The ticket listed both options. The deciding reason is concrete: **`MsSqlDdlBuilder` and `OracleDdlBuilder` are not in this repository at all.** `symmetric-db/platform` has ase, cassandra, db2, derby, firebird, greenplum, h2, hbase, hsqldb, informix, ingres, interbase, kafka, mysql, nuodb, postgresql, raima, redshift, sqlanywhere, sqlite, voltdb. No mssql, no oracle.

The reported failure is SQL Server 1913, so guarded DDL here would fix PostgreSQL — a platform that is not failing — and leave the affected customer waiting on a separate change.

Supporting: MySQL has no `CREATE INDEX IF NOT EXISTS` at all; Oracle needs a PL/SQL block that then has to survive `SqlScriptReader` delimiter splitting; and a name-based guard silently skips an index that exists with a *different definition*, which is precisely the situation that triggers this — so option 1's masking risk is not actually smaller.

## It needed no new plumbing

`doesObjectAlreadyExist` is **already** on `ISqlTemplate` with `objectAlreadyExistsCodes` / `objectAlreadyExistsStates` behind it, and `JdbcSqlTemplate` already holds the settings object that `ClientSymmetricEngine` populates. So:

- `objectAlreadyExistsMessageParts` adds cross-vendor message matching, which is what gives platforms outside this repository the fix with no per-platform change. Error codes stay per-platform, since the same number means different things on different vendors.
- The DDL statement loop tolerates create/alter failures that classify as already-exists, alongside the existing `isDrop` / `isSequenceCreate` handling, logging the skipped statement and the driver message at WARN.
- When tolerance is off and such a statement fails, the log now says the batch will fail identically on retry and should be ignored rather than cleared.
- `db.tolerate.object.already.exists.on.ddl`, default true, is the revert switch.

## Blast radius

**No interface signature changed and no emitted DDL changed.** The ~20 PRO platform subclasses of `AbstractDdlBuilder` that are invisible from this repo are unaffected, and both `PostgreSqlDdlBuilderTest` exact-string assertions pass untouched.

**A full PRO compile is still required before merge** — the OSS build passing proves nothing about the other platforms.

**1117 tests pass** across `symmetric-jdbc`, `symmetric-db`, `symmetric-io` and `symmetric-core`, 0 failures.

## Two things reviewers should weigh

**Cannot be verified without the vendors.** SQL Server 1913 and Oracle ORA-00955 message matching is what the OSS-only reach rests on, and server-localized messages defeat it. PRO should follow up by populating the per-platform error-code arrays; that is the real fix and this is the fallback. Worth adding both to the PRO integration matrix.

**The parameter is not database-overridable**, and the comment says so explicitly. It is read through `SqlTemplateSettings`, built once at startup from the properties file before `sym_parameter` is available, so it needs a restart. Its neighbours read the same way declare no `DatabaseOverridable` either. If we want it console-settable, the flag belongs on `DatabaseWriterSettings` threaded through `SqlScript` as a peer of `failOnDrops` — a bigger change that would touch `ISqlTemplate`/`IDatabasePlatform` signatures, which is exactly the blast radius this approach avoids. Happy to go that way if reviewers prefer it.

## Worth recording

The deeper cause is a **false-positive `AddIndexChange`**: `ModelComparator.findCorrespondingIndex` matches on full `IIndex.equals`, not name, while 1913 is a name collision. So the diff fires when the read-back model differs in definition from an index whose name already exists at the target. This change suppresses the symptom, not the model mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SYM-7916]: https://jumpmind.atlassian.net/browse/SYM-7916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ