### PR TITLE
SYM-7715: Fixed inaccurate description for the triggers.rebuilt.count metric

### DIFF
--- a/symmetric-assemble/src/asciidoc/manage/metrics.ad
+++ b/symmetric-assemble/src/asciidoc/manage/metrics.ad
@@ -138,6 +138,6 @@ endif::pro[]
 |Metric ID|Unit|Description
 
 |`triggers.created.count`|triggers|Database triggers created by the Sync Triggers Job
-|`triggers.rebuilt.count`|triggers|Database triggers rebuilt due to configuration or schema changes
+|`triggers.rebuilt.count`|triggers|Database triggers rebuilt for any reason
 |`triggers.removed.count`|triggers|Database triggers removed
 |===


### PR DESCRIPTION
The ticket description lists 2 possible approaches to resolve this issue:

1. Update the documentation to clarify that this metric tracks database triggers rebuilt for any reason
2. Only count a trigger as rebuilt if its `sym_trigger_hist.last_trigger_build_reason` is `S` or `C`

I took the first approach. Let me know if I should take the second approach instead.