### PR TITLE
SYM-7819: Documented Column Match router variable support and improved variable documentation

### DIFF
--- a/symmetric-assemble/src/asciidoc/advanced-topics.ad
+++ b/symmetric-assemble/src/asciidoc/advanced-topics.ad
@@ -525,6 +525,20 @@ Examples when `$(externalId)` is set to `1`:
 $(variableName|%05d) - returns 00001
 ----
 
+All variables supported via `$(variableName)` syntax:
+
+* Any parameter name
+* `groupId` - the node group ID of the node being evaluated or loaded
+* `nodeId` - the node ID of the node being evaluated or loaded
+* `externalId` - the external ID of the node being evaluated or loaded
+* `sourceGroupId` - the node group ID of the local (source) node
+* `sourceNodeId` - the node ID of the local (source) node
+* `sourceExternalId` - the external ID of the local (source) node
+* `sourceCatalogName` - the catalog name of the source table, from the trigger
+* `sourceSchemaName` - the schema name of the source table, from the trigger
+
+Not every configuration item supports every variable in this list - see that item's own documentation for the specific subset it substitutes.
+
 === OpenTelemetry Integration
 
 SymmetricDS publishes built-in metrics through the https://opentelemetry.io[OpenTelemetry] (OTel) API, making them available to any OTel-compatible observability platform such as Prometheus (via OTLP receiver), Grafana Cloud, DataDog, Dynatrace, etc.

--- a/symmetric-assemble/src/asciidoc/configuration/routers.ad
+++ b/symmetric-assemble/src/asciidoc/configuration/routers.ad
@@ -53,13 +53,11 @@ Router Expression:: An expression that is specific to the type of router that is
 [[use-source-catalog-schema]]Use Source Catalog/Schema:: If set then the source catalog and source schema are sent to the target to be used to find the target table.
 [[router-target-catalog]]Target Catalog:: Optional name of catalog where a target table is located. 
 If this field is unspecified, the catalog will be either the default catalog at the target node or the "source catalog name" from the table trigger, 
-depending on how "use source catalog schema" is set for the router.  Variables are substituted for `$(sourceNodeId)`, `$(sourceExternalId)`, `$(sourceNodeGroupId)`, 
-`$(targetNodeId)`, `$(targetExternalId)`, `$(targetNodeGroupId)`, `$(sourceCatalogName)`, and `$(sourceSchemaName)`.
+depending on how "use source catalog schema" is set for the router.  Variables are substituted for `$(sourceCatalogName)` and `$(sourceSchemaName)`.
 Parameter values can be substituted using `$(name)` syntax.  See <<Variables>>.
 [[router-target-schema]]Target Schema:: Optional name of schema where a target table is located. 
 If this field is unspecified, the schema will be either the default schema at the target node or the "source schema name" from the table trigger,
-depending on how "use source catalog schema" is set for the router.  Variables are substituted for `$(sourceNodeId)`, `$(sourceExternalId)`, `$(sourceNodeGroupId)`, 
-`$(targetNodeId)`, `$(targetExternalId)`, `$(targetNodeGroupId)`, `$(sourceCatalogName)`, and `$(sourceSchemaName)`.
+depending on how "use source catalog schema" is set for the router.  Variables are substituted for `$(sourceCatalogName)` and `$(sourceSchemaName)`.
 Parameter values can be substituted using `$(name)` syntax.  See <<Variables>>.
 
 ifdef::pro[]

--- a/symmetric-assemble/src/asciidoc/configuration/routers/column.ad
+++ b/symmetric-assemble/src/asciidoc/configuration/routers/column.ad
@@ -52,7 +52,24 @@ STATUS!=:OLD_STATUS
 * :SOURCE_CATALOG
 ====
 
-. Consider a table that needs to be routed to only nodes in the target group whose STORE_ID column matches the external id of a node. 
+[TIP]
+.The value side of the expression also supports `$(variableName)` syntax
+====
+This includes substring and format-string modifiers - see <<Variables>> for the full syntax reference. This router supports `groupId`, `nodeId`,
+and `externalId` (evaluated per node being matched against), `sourceGroupId`, `sourceNodeId`, and `sourceExternalId` (the local/source node), and
+any parameter.
+====
+
+. Consider a table that needs to be routed to nodes whose STORE_ID matches the first 5 characters of the target node's external id.
+
+.Router Expression
+
+----
+STORE_ID=$(externalId:0:5)
+----
+
+
+. Consider a table that needs to be routed to only nodes in the target group whose STORE_ID column matches the external id of a node.
 
 .Router Expression
 


### PR DESCRIPTION
Regarding the change to `routers.ad`, I discovered that some of the variables that the documentation stated were supported for a router's target catalog/schema are not actually supported.