### PR TITLE
SYM-7714: Fixed triggers created when Sync Triggers runs for the first time not getting counted toward the triggers.created.count metric

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -834,6 +834,7 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
     }
 
     private void startNodeAndJobs(Node node, boolean startJobs) {
+        ensureMetricsServiceIsCreated();
         node = checkSystemIntegrity(node);
         isInitialized = true;
         if (node != null) {
@@ -857,7 +858,6 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
             log.info("Starting unregistered node [group={}, externalId={}]",
                     parameterService.getNodeGroupId(), parameterService.getExternalId());
         }
-        ensureMetricsServiceIsCreated();
         if (jobManager != null) {
             jobManager.init();
         }


### PR DESCRIPTION
This issue originally occurred back in 3.18.0.RC0. Since then, there have been some changes to the metrics functionality and how the metrics are initialized.

I saw that the changes for SYM-7697 moved the `EngineMetricsService` creation after the first `syncTriggers()` call, which makes it impossible to capture metrics the first time Sync Triggers runs. I changed the order so that `EngineMetricsService` is created before `syncTriggers()` is called. I wasn't expecting this to completely fix the issue (since the issue originally occurred before the changes for SYM-7697 were merged), but it actually did.

I think the other changes that were made for SYM-7697 helped resolve this issue. I'm thinking that before these changes, `EngineMetricsService` was getting into a bad state because it was being initialized with an empty database, and this may have caused metrics like `triggers.created.count` to not work as expected shortly after startup.