### PR TITLE
SYM-7887: Log4j -> Logback migration isn't documented II

### DIFF
--- a/symmetric-assemble/src/asciidoc/installation.ad
+++ b/symmetric-assemble/src/asciidoc/installation.ad
@@ -589,10 +589,12 @@ Upgrading an existing SymmetricDS instance depends on the deployment option used
 NOTE: When upgrading to 3.18 from any earlier version, the logging framework changes from Log4j2 to
 Logback, and `conf/log4j2.xml` is replaced by `conf/logback.xml`. 
 ifdef::pro[]
-The setup program deprecates and converts your existing configuration, but a few Log4j2 constructs cannot be translated automatically. See <<Migrating from Log4j to Logback>> for what is converted and what to check afterwards.
+The setup program deprecates and converts your existing configuration, but a few Log4j2 constructs cannot be translated automatically.
 endif::pro[]
+See <<Migrating from Log4j to Logback>> for what is converted and what to check afterwards.
 
 ifdef::pro[]
+
 ==== Upgrade SymmetricDS Cluster
 
 Upgrading a cluster with multiple SymmetricDS installations requires careful coordination. Below are the most important steps. However, it is recommended to test the entire upgrade process in a non-Production environment and to measure time each step took.
@@ -634,6 +636,7 @@ Contact mailto:sales@jumpmind.com[JumpStart,Upgrade Project,How JumpStart can he
 * Ensure load balancer detects changes (server is listed as offline);
 * Confirm that the SymmetricDS engine runs automatically at system start-up.
 . Enable any external application jobs or batch processes.
+
 endif::pro[]
 
 

--- a/symmetric-assemble/src/asciidoc/manage/logging.ad
+++ b/symmetric-assemble/src/asciidoc/manage/logging.ad
@@ -18,10 +18,11 @@ endif::pro[]
 
 ==== Migrating from Log4j to Logback
 
-SymmetricDS 3.18 replaced Log4j2 with Logback. 
+SymmetricDS 3.18 replaced Log4j2 with Logback. If you are upgrading from 3.17 or earlier, your `log4j2.xml` file is no longer read.
 ifdef::pro[]
-If you are upgrading from 3.17 or earlier, your `log4j2.xml` file is no longer read and its contents are translated into `logback.xml`.
+Its contents are translated into `logback.xml` during the upgrade.
 endif::pro[]
+
 .What changes
 [cols="1,1", options="header"]
 |===
@@ -95,7 +96,7 @@ it back off again afterwards.
 ===== Translating your configuration
 
 Use this section when you are migrating a configuration by hand, or when you need to re-apply
-something the setup program reported it could not convert.
+something the symmetricDS PRO setup program reported it could not convert.
 
 Logback uses lowercase element names, drops the `<Appenders>` and `<Loggers>` wrapper elements, and
 expresses several settings as child elements rather than attributes.

--- a/symmetric-assemble/src/asciidoc/manage/logging.ad
+++ b/symmetric-assemble/src/asciidoc/manage/logging.ad
@@ -96,7 +96,7 @@ it back off again afterwards.
 ===== Translating your configuration
 
 Use this section when you are migrating a configuration by hand, or when you need to re-apply
-something the symmetricDS PRO setup program reported it could not convert.
+something the SymmetricDS PRO setup program reported it could not convert.
 
 Logback uses lowercase element names, drops the `<Appenders>` and `<Loggers>` wrapper elements, and
 expresses several settings as child elements rather than attributes.

--- a/symmetric-assemble/src/asciidoc/release-notes/whats-new.ad
+++ b/symmetric-assemble/src/asciidoc/release-notes/whats-new.ad
@@ -197,7 +197,7 @@ ifndef::pro[]
 *An existing log4j2.xml configuration from versions of SymmetricDS older than 3.18 needs to be manually converted to logback.xml! Automatic conversion is a SymmetricDS Pro feature.*
 endif::pro[]
 
-The Logging chapter of the SymmetricDS User Guide contains a full translation guide for these cases, including a before and after example and a table mapping every Log4j2 element and attribute to its Logback equivalent.
+The Logging chapter of the SymmetricDS User Guide contains a full translation guide, including a before and after example and a table mapping every Log4j2 element and attribute to its Logback equivalent.
 
 Behavior changes worth noting:
 


### PR DESCRIPTION
Second follow up PR -> there were some fixes that didn't get included in the previous merge.

Original ticket: https://jumpmind.atlassian.net/browse/SYM-7887