### PR TITLE
SYM-7960: Fixed Postgres endpoint deployment failure

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -1111,14 +1111,14 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
 
     private void removeEngineFromAppHealthTracker() {
         IApplicationHealthTracker appHealthTracker = ApplicationHealthTracker.getTracker();
-        if (appHealthTracker != null) {
+        if (appHealthTracker != null && parameterService != null) {
             appHealthTracker.stopTrackingEngine(getEngineName());
         }
     }
 
     private void setEngineReadinessInAppHealthTracker(boolean isReady) {
         IApplicationHealthTracker appHealthTracker = ApplicationHealthTracker.getTracker();
-        if (appHealthTracker != null) {
+        if (appHealthTracker != null && parameterService != null) {
             appHealthTracker.setEngineReadiness(getEngineName(), isReady);
         }
     }

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -153,13 +153,13 @@ db.pool.initial.size=5
 #   HikariCP: caps the total pool size (active + idle combined); db.pool.max.idle is ignored.
 # Tags: database
 # Type: integer
-db.pool.max.active=100
+db.pool.max.active=50
 
 # The maximum number of connections that can remain idle in the pool, without extra ones
 # being released
 # Tags: database
 # Type: integer
-db.pool.max.idle=100
+db.pool.max.idle=50
 
 # The minimum number of idle connections to maintain in the pool.
 #
@@ -174,7 +174,7 @@ db.pool.max.idle=100
 #			  recommended to avoid stale-connection leaks.
 # Tags: database
 # Type: integer
-db.pool.min.idle=100
+db.pool.min.idle=50
 
 # SQL query executed just before a connection is given to the caller to verify the connection is still alive.
 # Also known as connectionTestQuery in HikariCP.


### PR DESCRIPTION
The change to `AbstractSymmetricEngine` fixes the NPE. After fixing the NPE, I found that the problem is that our default database connection pool size is equal to Postgres' default `max_connections`, which causes an error due to not enough connections being available. The change to `symmetric-default.properties` reduces the default database connection pool size from 100 to 50, which resolves the error (when deploying only one Postgres node) and matches the default maximum pool size from 3.17.