### PR TITLE
SYM-7962: Fix LONG VARCHAR type mapping mistmatch between Db2DdlReader and Db2DdlBuilder

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
@@ -333,12 +333,16 @@ public class Db2DdlReader extends AbstractJdbcDdlReader {
         } else if (typeName != null && typeName.endsWith("CLOB")) {
             return Types.LONGVARCHAR;
         } else if (typeName != null && typeName.endsWith("LONG VARCHAR")) {
-            return Types.CLOB;
+            return getMappedTypeForLongVarChar();
         } else if (typeName != null && typeName.endsWith("XML")) {
             return Types.SQLXML;
         } else {
             return super.mapUnknownJdbcTypeForColumn(values);
         }
+    }
+
+    protected Integer getMappedTypeForLongVarChar() {
+        return Types.LONGVARCHAR;
     }
 
     @Override


### PR DESCRIPTION
There is a matching PR for this in symmetric-pro to preserve the behavior of Db2 zOS and Db2 AS400.