### PR TITLE
SYM-7723: Fixed rows.create.time.min and rows.create.time.max metrics not tracking unrouted data as expected

### DIFF
--- a/symmetric-assemble/src/asciidoc/installation.ad
+++ b/symmetric-assemble/src/asciidoc/installation.ad
@@ -675,6 +675,7 @@ The following environment variables control whether a given SymmetricDS job is a
 |SYM_START_PURGE_INCOMING_JOB|start.purge.incoming.job|true
 |SYM_START_PURGE_METRIC_STATS_JOB|start.purge.metric.stats.job|true
 |SYM_START_REFRESH_BACKLOG_REPORT_JOB|start.refresh.backlog.report.job|true
+|SYM_START_REFRESH_DATA_CREATE_TIME_METRICS_JOB|start.refresh.data.create.time.metrics.job|true
 |SYM_START_HEARTBEAT_JOB|start.heartbeat.job|true
 |SYM_START_SYNCTRIGGERS_JOB|start.synctriggers.job|true
 |SYM_START_SYNC_CONFIG_JOB|start.sync.config.job|true

--- a/symmetric-assemble/src/asciidoc/manage/jobs.ad
+++ b/symmetric-assemble/src/asciidoc/manage/jobs.ad
@@ -146,13 +146,13 @@ The Initial Load Extract Job processes <<EXTRACT_REQUEST>>s.  See <<Initial Load
 
 The Refresh Backlog Report Job queries <<OUTGOING_BATCH>> and <<INCOMING_BATCH>> to compute batch and row counts (by node and batch status) to update the batch status metrics gauges.
 
+ifdef::pro[]
+Also, this job saves a snapshot of the outgoing backlog to the <<ANALYTICS_REPORT>> table, which is displayed under the Analytics tab.
+
 ==== Refresh Data Create Time Metrics Job
 
 The Refresh Data Create Time Metrics Job queries <<DATA>> for the oldest and most recent create time of unrouted
 rows, grouped by channel, to update the `rows.create.time.min` and `rows.create.time.max` metrics.
-
-ifdef::pro[]
-Also, this job saves a snapshot of the outgoing backlog to the <<ANALYTICS_REPORT>> table, which is displayed under the Analytics tab.
 
 ==== Compare Job
 

--- a/symmetric-assemble/src/asciidoc/manage/jobs.ad
+++ b/symmetric-assemble/src/asciidoc/manage/jobs.ad
@@ -146,6 +146,11 @@ The Initial Load Extract Job processes <<EXTRACT_REQUEST>>s.  See <<Initial Load
 
 The Refresh Backlog Report Job queries <<OUTGOING_BATCH>> to compute batch and row counts (by node and batch status) to update the outgoing backlog metrics gauges.
 
+==== Refresh Data Create Time Metrics Job
+
+The Refresh Data Create Time Metrics Job queries <<DATA>> for the oldest and most recent create time of unrouted
+rows, grouped by channel, to update the `rows.create.time.min` and `rows.create.time.max` metrics.
+
 ifdef::pro[]
 Also, this job saves a snapshot of the outgoing backlog to the <<ANALYTICS_REPORT>> table, which is displayed under the Analytics tab.
 

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/job/BuiltInJobs.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/job/BuiltInJobs.java
@@ -50,6 +50,7 @@ public class BuiltInJobs {
         builtInJobs.add(new StatisticFlushJob(engine, taskScheduler));
         builtInJobs.add(new PurgeMetricStatsJob(engine, taskScheduler));
         builtInJobs.add(createJob(RefreshBacklogReportJob.class, engine, taskScheduler));
+        builtInJobs.add(createJob(RefreshDataCreateTimeMetricsJob.class, engine, taskScheduler));
         builtInJobs.add(new SyncTriggersJob(engine, taskScheduler));
         builtInJobs.add(new HeartbeatJob(engine, taskScheduler));
         builtInJobs.add(new WatchdogJob(engine, taskScheduler));

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/job/RefreshDataCreateTimeMetricsJob.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/job/RefreshDataCreateTimeMetricsJob.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.job;
+
+import static org.jumpmind.symmetric.job.JobDefaults.EVERY_FIFTEEN_MINUTES;
+
+import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.service.ClusterConstants;
+import org.jumpmind.symmetric.statistic.IStatisticManager;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+public class RefreshDataCreateTimeMetricsJob extends AbstractJob {
+    public RefreshDataCreateTimeMetricsJob(ISymmetricEngine engine, ThreadPoolTaskScheduler taskScheduler) {
+        super(ClusterConstants.REFRESH_DATA_CREATE_TIME_METRICS, engine, taskScheduler);
+    }
+
+    @Override
+    public JobDefaults getDefaults() {
+        return new JobDefaults()
+                .schedule(EVERY_FIFTEEN_MINUTES)
+                .description("Refresh unrouted data create time metrics");
+    }
+
+    @Override
+    protected long getMinSchedulePeriodMs() {
+        return Long.parseLong(EVERY_FIFTEEN_MINUTES);
+    }
+
+    @Override
+    public boolean isRateLimited() {
+        return true;
+    }
+
+    @Override
+    public void doJob(boolean force) throws Exception {
+        IStatisticManager statisticManager = engine.getStatisticManager();
+        for (ChannelDataCreateTimeRange range : engine.getRouterService().findUnroutedDataCreateTimeRangeByChannel()) {
+            statisticManager.setDataUnroutedMinCreateTime(range.channelId(), range.minCreateTime());
+            statisticManager.setDataUnroutedMaxCreateTime(range.channelId(), range.maxCreateTime());
+        }
+    }
+}

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/job/RefreshDataCreateTimeMetricsJobTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/job/RefreshDataCreateTimeMetricsJobTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.job;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.jumpmind.symmetric.service.IRouterService;
+import org.jumpmind.symmetric.statistic.IStatisticManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+class RefreshDataCreateTimeMetricsJobTest {
+    private ISymmetricEngine engine;
+    private IParameterService parameterService;
+    private IRouterService routerService;
+    private IStatisticManager statisticManager;
+    private ThreadPoolTaskScheduler taskScheduler;
+
+    @BeforeEach
+    void setUp() {
+        engine = mock(ISymmetricEngine.class);
+        parameterService = mock(IParameterService.class);
+        routerService = mock(IRouterService.class);
+        statisticManager = mock(IStatisticManager.class);
+        taskScheduler = mock(ThreadPoolTaskScheduler.class);
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(parameterService.getExternalId()).thenReturn("test-node");
+        when(parameterService.getInt(anyString())).thenReturn(10000);
+        when(engine.getRouterService()).thenReturn(routerService);
+        when(engine.getStatisticManager()).thenReturn(statisticManager);
+    }
+
+    private RefreshDataCreateTimeMetricsJob newJob() {
+        return new RefreshDataCreateTimeMetricsJob(engine, taskScheduler);
+    }
+
+    @Test
+    void getDefaults_returnsNonNull() {
+        assertNotNull(newJob().getDefaults());
+    }
+
+    @Test
+    void isRateLimited_returnsTrue() {
+        assertTrue(newJob().isRateLimited());
+    }
+
+    @Test
+    void getMinSchedulePeriodMs_matchesEveryFifteenMinutes() {
+        long expected = Long.parseLong(JobDefaults.EVERY_FIFTEEN_MINUTES);
+        assertEquals(expected, newJob().getMinSchedulePeriodMs());
+    }
+
+    @Test
+    void doJob_callsFindUnroutedDataCreateTimeRangeByChannel() {
+        when(routerService.findUnroutedDataCreateTimeRangeByChannel()).thenReturn(Collections.emptyList());
+        assertDoesNotThrow(() -> newJob().doJob(false));
+        verify(routerService).findUnroutedDataCreateTimeRangeByChannel();
+    }
+
+    @Test
+    void doJob_emptyList_noStatisticManagerCallsMade() throws Exception {
+        when(routerService.findUnroutedDataCreateTimeRangeByChannel()).thenReturn(Collections.emptyList());
+        newJob().doJob(false);
+        verify(statisticManager, never()).setDataUnroutedMinCreateTime(any(), any());
+        verify(statisticManager, never()).setDataUnroutedMaxCreateTime(any(), any());
+    }
+
+    @Test
+    void doJob_singleChannelRange_setsMinAndMaxCreateTime() throws Exception {
+        Date minTime = new Date(1000L);
+        Date maxTime = new Date(2000L);
+        when(routerService.findUnroutedDataCreateTimeRangeByChannel())
+                .thenReturn(List.of(new ChannelDataCreateTimeRange("chan1", minTime, maxTime)));
+        newJob().doJob(false);
+        verify(statisticManager).setDataUnroutedMinCreateTime("chan1", minTime);
+        verify(statisticManager).setDataUnroutedMaxCreateTime("chan1", maxTime);
+    }
+
+    @Test
+    void doJob_multipleChannelRanges_setsEachChannel() throws Exception {
+        Date minTime1 = new Date(1000L);
+        Date maxTime1 = new Date(2000L);
+        Date minTime2 = new Date(3000L);
+        Date maxTime2 = new Date(4000L);
+        when(routerService.findUnroutedDataCreateTimeRangeByChannel())
+                .thenReturn(List.of(
+                        new ChannelDataCreateTimeRange("chan1", minTime1, maxTime1),
+                        new ChannelDataCreateTimeRange("chan2", minTime2, maxTime2)));
+        newJob().doJob(false);
+        verify(statisticManager).setDataUnroutedMinCreateTime("chan1", minTime1);
+        verify(statisticManager).setDataUnroutedMaxCreateTime("chan1", maxTime1);
+        verify(statisticManager).setDataUnroutedMinCreateTime("chan2", minTime2);
+        verify(statisticManager).setDataUnroutedMaxCreateTime("chan2", maxTime2);
+    }
+}

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -73,6 +73,7 @@ final public class ParameterConstants {
     public static final String START_OFFLINE_PUSH_JOB = "start.offline.push.job";
     public static final String START_REFRESH_CACHE_JOB = "start.refresh.cache.job";
     public static final String START_REFRESH_BACKLOG_REPORT_JOB = "start.refresh.backlog.report.job";
+    public static final String START_REFRESH_DATA_CREATE_TIME_METRICS_JOB = "start.refresh.data.create.time.metrics.job";
     public static final String START_FILE_SYNC_TRACKER_JOB = "start.file.sync.tracker.job";
     public static final String START_FILE_SYNC_PUSH_JOB = "start.file.sync.push.job";
     public static final String START_FILE_SYNC_PULL_JOB = "start.file.sync.pull.job";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ChannelDataCreateTimeRange.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ChannelDataCreateTimeRange.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.model;
+
+import java.util.Date;
+
+/**
+ * One row from a gap-qualified query of {@code sym_data}: the oldest and most recent {@code create_time} of unrouted rows, grouped by channel.
+ */
+public record ChannelDataCreateTimeRange(String channelId, Date minCreateTime, Date maxCreateTime) {
+}

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
@@ -61,6 +61,7 @@ public class ClusterConstants {
     public static final String LOG_MINER = "Log Miner";
     public static final String REFRESH_ANALYTICS = "Refresh Analytics";
     public static final String REFRESH_BACKLOG_REPORT = "Refresh Backlog Report";
+    public static final String REFRESH_DATA_CREATE_TIME_METRICS = "Refresh Data Create Time Metrics";
     public static final String JUMPMIND_TOKEN_REFRESH = "Jumpmind Token Refresh";
     public static final String FILE_SYNC_SHARED = "FILE_SYNC_SHARED";
     public static final String TYPE_CLUSTER = "CLUSTER";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IRouterService.java
@@ -23,6 +23,7 @@ package org.jumpmind.symmetric.service;
 import java.util.List;
 import java.util.Map;
 
+import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.DataMetaData;
 import org.jumpmind.symmetric.model.Node;
@@ -41,6 +42,8 @@ public interface IRouterService extends IService {
     public long getMaxDataIdAlreadyRouted();
 
     public long getUnroutedDataCount();
+
+    public List<ChannelDataCreateTimeRange> findUnroutedDataCreateTimeRangeByChannel();
 
     public boolean shouldDataBeRouted(SimpleRouterContext context, DataMetaData dataMetaData,
             Node node, boolean initialLoad, boolean initialLoadSelectUsed, TriggerRouter triggerRouter);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +46,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.Relation;
 import org.jumpmind.db.model.Table;
-import org.jumpmind.db.sql.ISqlRowMapper;
 import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.db.sql.Row;
 import org.jumpmind.symmetric.ISymmetricEngine;
@@ -390,11 +390,9 @@ public class RouterService extends AbstractService implements IRouterService, IN
         GapQualifiedQuery query = buildGapQualifiedQuery(gapDetector.getDataGaps(),
                 "selectChannelsUsingGapsSql", "selectChannelsUsingStartDataId");
         final Set<String> readyChannels = new HashSet<String>();
-        sqlTemplateDirty.query(query.sql(), new ISqlRowMapper<String>() {
-            public String mapRow(Row row) {
-                readyChannels.add(row.getString("channel_id"));
-                return null;
-            }
+        sqlTemplateDirty.query(query.sql(), (Row row) -> {
+            readyChannels.add(row.getString("channel_id"));
+            return null;
         }, query.args(), query.types());
         return readyChannels;
     }
@@ -406,12 +404,8 @@ public class RouterService extends AbstractService implements IRouterService, IN
         }
         GapQualifiedQuery query = buildGapQualifiedQuery(dataGaps,
                 "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
-        return sqlTemplateDirty.query(query.sql(), new ISqlRowMapper<ChannelDataCreateTimeRange>() {
-            public ChannelDataCreateTimeRange mapRow(Row row) {
-                return new ChannelDataCreateTimeRange(row.getString("channel_id"),
-                        row.getDateTime("min_create_time"), row.getDateTime("max_create_time"));
-            }
-        }, query.args(), query.types());
+        return sqlTemplateDirty.query(query.sql(), (Row row) -> new ChannelDataCreateTimeRange(row.getString("channel_id"),
+                row.getDateTime("min_create_time"), row.getDateTime("max_create_time")), query.args(), query.types());
     }
 
     protected GapQualifiedQuery buildGapQualifiedQuery(List<DataGap> dataGaps, String gapsSqlKey, String startIdSqlKey) {
@@ -1408,5 +1402,26 @@ public class RouterService extends AbstractService implements IRouterService, IN
     }
 
     protected record GapQualifiedQuery(String sql, Object[] args, int[] types) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GapQualifiedQuery)) {
+                return false;
+            }
+            GapQualifiedQuery other = (GapQualifiedQuery) o;
+            return Objects.equals(sql, other.sql) && Arrays.equals(args, other.args) && Arrays.equals(types, other.types);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sql, Arrays.hashCode(args), Arrays.hashCode(types));
+        }
+
+        @Override
+        public String toString() {
+            return "GapQualifiedQuery[sql=" + sql + ", args=" + Arrays.toString(args) + ", types=" + Arrays.toString(types) + "]";
+        }
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -59,6 +59,7 @@ import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.io.data.ProtocolException;
 import org.jumpmind.symmetric.model.AbstractBatch.Status;
 import org.jumpmind.symmetric.model.Channel;
+import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
 import org.jumpmind.symmetric.model.Data;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.DataMetaData;
@@ -386,7 +387,34 @@ public class RouterService extends AbstractService implements IRouterService, IN
     }
 
     protected Set<String> getReadyChannels() {
+        GapQualifiedQuery query = buildGapQualifiedQuery(gapDetector.getDataGaps(),
+                "selectChannelsUsingGapsSql", "selectChannelsUsingStartDataId");
+        final Set<String> readyChannels = new HashSet<String>();
+        sqlTemplateDirty.query(query.sql(), new ISqlRowMapper<String>() {
+            public String mapRow(Row row) {
+                readyChannels.add(row.getString("channel_id"));
+                return null;
+            }
+        }, query.args(), query.types());
+        return readyChannels;
+    }
+
+    public List<ChannelDataCreateTimeRange> findUnroutedDataCreateTimeRangeByChannel() {
         List<DataGap> dataGaps = gapDetector.getDataGaps();
+        if (dataGaps == null || dataGaps.isEmpty()) {
+            return Collections.emptyList();
+        }
+        GapQualifiedQuery query = buildGapQualifiedQuery(dataGaps,
+                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
+        return sqlTemplateDirty.query(query.sql(), new ISqlRowMapper<ChannelDataCreateTimeRange>() {
+            public ChannelDataCreateTimeRange mapRow(Row row) {
+                return new ChannelDataCreateTimeRange(row.getString("channel_id"),
+                        row.getDateTime("min_create_time"), row.getDateTime("max_create_time"));
+            }
+        }, query.args(), query.types());
+    }
+
+    protected GapQualifiedQuery buildGapQualifiedQuery(List<DataGap> dataGaps, String gapsSqlKey, String startIdSqlKey) {
         int dataIdSqlType = engine.getSymmetricDialect().getSqlTypeForIds();
         int numberOfGapsToQualify = parameterService.getInt(ParameterConstants.ROUTING_MAX_GAPS_TO_QUALIFY_IN_SQL, 100);
         int maxGapsBeforeGreaterThanQuery = parameterService.getInt(
@@ -395,11 +423,11 @@ public class RouterService extends AbstractService implements IRouterService, IN
         Object[] args;
         int[] types;
         if (maxGapsBeforeGreaterThanQuery > 0 && dataGaps.size() > maxGapsBeforeGreaterThanQuery) {
-            sql = getSql("selectChannelsUsingStartDataId");
+            sql = getSql(startIdSqlKey);
             args = new Object[] { dataGaps.get(0).getStartId() };
             types = new int[] { dataIdSqlType };
         } else {
-            sql = qualifyUsingDataGaps(dataGaps, numberOfGapsToQualify, getSql("selectChannelsUsingGapsSql"));
+            sql = qualifyUsingDataGaps(dataGaps, numberOfGapsToQualify, getSql(gapsSqlKey));
             int numberOfArgs = 2 * (numberOfGapsToQualify < dataGaps.size() ? numberOfGapsToQualify : dataGaps.size());
             args = new Object[numberOfArgs];
             types = new int[numberOfArgs];
@@ -415,14 +443,7 @@ public class RouterService extends AbstractService implements IRouterService, IN
                 types[i * 2 + 1] = dataIdSqlType;
             }
         }
-        final Set<String> readyChannels = new HashSet<String>();
-        sqlTemplateDirty.query(sql, new ISqlRowMapper<String>() {
-            public String mapRow(Row row) {
-                readyChannels.add(row.getString("channel_id"));
-                return null;
-            }
-        }, args, types);
-        return readyChannels;
+        return new GapQualifiedQuery(sql, args, types);
     }
 
     protected String qualifyUsingDataGaps(List<DataGap> dataGaps, int numberOfGapsToQualify,
@@ -932,10 +953,10 @@ public class RouterService extends AbstractService implements IRouterService, IN
                                 statisticManager.incrementDataEventInserted(channelId, statsDataEventCount);
                                 statsDataEventCount = 0;
                                 if (minCreateTime != null) {
-                                    statisticManager.updateDataMinCreateTime(channelId, minCreateTime);
+                                    statisticManager.updateDataRoutedMinCreateTime(channelId, minCreateTime);
                                 }
                                 if (maxCreateTime != null) {
-                                    statisticManager.updateDataMaxCreateTime(channelId, maxCreateTime);
+                                    statisticManager.updateDataRoutedMaxCreateTime(channelId, maxCreateTime);
                                 }
                             }
                         }
@@ -986,10 +1007,10 @@ public class RouterService extends AbstractService implements IRouterService, IN
                 statisticManager.incrementDataEventInserted(channelId, statsDataEventCount);
             }
             if (minCreateTime != null) {
-                statisticManager.updateDataMinCreateTime(channelId, minCreateTime);
+                statisticManager.updateDataRoutedMinCreateTime(channelId, minCreateTime);
             }
             if (maxCreateTime != null) {
-                statisticManager.updateDataMaxCreateTime(channelId, maxCreateTime);
+                statisticManager.updateDataRoutedMaxCreateTime(channelId, maxCreateTime);
             }
         }
         context.incrementStat(totalDataCount, ChannelRouterContext.STAT_DATA_ROUTED_COUNT);
@@ -1384,5 +1405,8 @@ public class RouterService extends AbstractService implements IRouterService, IN
             }
         }
         return true;
+    }
+
+    protected record GapQualifiedQuery(String sql, Object[] args, int[] types) {
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
@@ -29,6 +29,12 @@ public class RouterServiceSqlMap extends AbstractSqlMap {
         super(platform, replacementTokens);
         putSql("selectChannelsUsingGapsSql", "select distinct channel_id from $(data) where $(dataRange)");
         putSql("selectChannelsUsingStartDataId", "select distinct channel_id from $(data) where data_id >= ?");
+        putSql("selectChannelDataCreateTimeRangeUsingGapsSql",
+                "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
+                        + "from $(data) where $(dataRange) group by channel_id");
+        putSql("selectChannelDataCreateTimeRangeUsingStartDataId",
+                "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
+                        + "from $(data) where data_id >= ? group by channel_id");
         putSql("selectDataUsingGapsSql",
                 "select $(selectDataUsingGapsSqlHint) d.data_id, d.table_name, d.event_type, d.row_data as row_data, d.pk_data as pk_data, d.old_data as old_data, "
                         + " d.create_time, d.trigger_hist_id, d.channel_id, d.transaction_id, d.source_node_id, d.external_data, d.node_list, d.is_prerouted "

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/IStatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/IStatisticManager.java
@@ -100,9 +100,13 @@ public interface IStatisticManager {
 
     public void incrementDataSentErrors(String channelId, long count);
 
-    public void updateDataMinCreateTime(String channelId, Date minCreateTime);
+    public void updateDataRoutedMinCreateTime(String channelId, Date minCreateTime);
 
-    public void updateDataMaxCreateTime(String channelId, Date maxCreateTime);
+    public void updateDataRoutedMaxCreateTime(String channelId, Date maxCreateTime);
+
+    public void setDataUnroutedMinCreateTime(String channelId, Date minCreateTime);
+
+    public void setDataUnroutedMaxCreateTime(String channelId, Date maxCreateTime);
 
     public void incrementRestart();
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -466,23 +466,41 @@ public class StatisticManager implements IStatisticManager {
         addChannelCounter(METRIC_ID_DATA_LOADED_OUTGOING_ERRORS, channelId, count);
     }
 
-    public void updateDataMinCreateTime(String channelId, Date minCreateTime) {
+    /**
+     * Tracks the minimum create time of routed data for the {@code node_host_channel_stats} table.
+     */
+    public void updateDataRoutedMinCreateTime(String channelId, Date minCreateTime) {
         channelStatsLock.acquireUninterruptibly();
         try {
             getChannelStats(channelId).updateDataMinCreateTime(minCreateTime);
         } finally {
             channelStatsLock.release();
         }
-        setChannelLongGauge(METRIC_ID_DATA_CREATE_TIME_MIN, channelId, minCreateTime.getTime());
     }
 
-    public void updateDataMaxCreateTime(String channelId, Date maxCreateTime) {
+    /**
+     * Tracks the maximum create time of routed data for the {@code node_host_channel_stats} table.
+     */
+    public void updateDataRoutedMaxCreateTime(String channelId, Date maxCreateTime) {
         channelStatsLock.acquireUninterruptibly();
         try {
             getChannelStats(channelId).updateDataMaxCreateTime(maxCreateTime);
         } finally {
             channelStatsLock.release();
         }
+    }
+
+    /**
+     * Updates the {@code rows.create.time.min} metric gauge with the current minimum create time of unrouted data.
+     */
+    public void setDataUnroutedMinCreateTime(String channelId, Date minCreateTime) {
+        setChannelLongGauge(METRIC_ID_DATA_CREATE_TIME_MIN, channelId, minCreateTime.getTime());
+    }
+
+    /**
+     * Updates the {@code rows.create.time.max} metric gauge with the current maximum create time of unrouted data.
+     */
+    public void setDataUnroutedMaxCreateTime(String channelId, Date maxCreateTime) {
         setChannelLongGauge(METRIC_ID_DATA_CREATE_TIME_MAX, channelId, maxCreateTime.getTime());
     }
 

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -1595,6 +1595,12 @@ job.purge.metric.stats.cron=0 0 0 * * *
 # Tags: jobs
 job.refresh.backlog.report.period.time.ms=900000
 
+# This is how often the refresh data create time metrics job will run.
+#
+# DatabaseOverridable: true
+# Tags: jobs
+job.refresh.data.create.time.metrics.period.time.ms=900000
+
 # This is when the sync triggers job will run.
 #
 # DatabaseOverridable: true
@@ -1738,6 +1744,12 @@ start.purge.metric.stats.job=true
 # Tags: jobs
 # Type: boolean
 start.refresh.backlog.report.job=true
+
+# Whether the refresh data create time metrics job is enabled for this node.
+#
+# Tags: jobs
+# Type: boolean
+start.refresh.data.create.time.metrics.job=true
 
 # Whether the heartbeat job is enabled for this node.  The heartbeat job simply
 # inserts an event to update the heartbeat_time column on the node_host table for the current node.

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -34,17 +34,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.sql.ISqlRowMapper;
+import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.ISqlTransaction;
+import org.jumpmind.db.sql.Row;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.common.TableConstants;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.model.Channel;
+import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
 import org.jumpmind.symmetric.model.Data;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.Node;
@@ -54,6 +59,7 @@ import org.jumpmind.symmetric.model.Router;
 import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.model.TriggerRouter;
 import org.jumpmind.symmetric.route.ChannelRouterContext;
+import org.jumpmind.symmetric.route.DataGapDetector;
 import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IExtensionService;
 import org.jumpmind.symmetric.service.IGroupletService;
@@ -363,6 +369,7 @@ public class RouterServiceTest {
         IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(databasePlatform.scrubSql(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(databasePlatform.getSqlTemplateDirty()).thenReturn(mock(ISqlTemplate.class));
         when(parameterService.getTablePrefix()).thenReturn("sym");
         when(parameterService.getInt(ParameterConstants.ROUTING_MAX_GAPS_TO_QUALIFY_IN_SQL, 100)).thenReturn(maxGapsToQualify);
         when(parameterService.getInt(ParameterConstants.ROUTING_DATA_READER_THRESHOLD_GAPS_TO_USE_GREATER_QUERY, 100))
@@ -371,7 +378,8 @@ public class RouterServiceTest {
         when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
         when(engine.getParameterService()).thenReturn(parameterService);
         when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
-        when(engine.getExtensionService()).thenReturn(mock(IExtensionService.class));
+        IExtensionService extensionService = mock(IExtensionService.class);
+        when(engine.getExtensionService()).thenReturn(extensionService);
         RouterService testRouterService = new RouterService(engine);
         testRouterService.setSqlMap(new RouterServiceSqlMap(databasePlatform,
                 Collections.singletonMap("data", TableConstants.getTableName("sym", TableConstants.SYM_DATA))));
@@ -402,6 +410,50 @@ public class RouterServiceTest {
         assertTrue(query.sql().contains("data_id >= ?"));
         assertEquals(1, query.args().length);
         assertEquals(1L, query.args()[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stubQueryToInvokeMapper(ISqlTemplate sqlTemplate, List<Row> rows) {
+        when(sqlTemplate.query(any(), any(ISqlRowMapper.class), any(Object[].class), any(int[].class))).thenAnswer(invocation -> {
+            ISqlRowMapper<Object> mapper = invocation.getArgument(1);
+            List<Object> results = new ArrayList<>();
+            for (Row row : rows) {
+                results.add(mapper.mapRow(row));
+            }
+            return results;
+        });
+    }
+
+    @Test
+    public void testGetReadyChannelsMapsChannelIdsFromQueryResults() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        testRouterService.gapDetector = mock(DataGapDetector.class);
+        when(testRouterService.gapDetector.getDataGaps()).thenReturn(Arrays.asList(new DataGap(1, 10)));
+        stubQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(
+                new Row("channel_id", "chan1"),
+                new Row("channel_id", "chan2")));
+        Collection<String> readyChannels = testRouterService.getReadyChannels();
+        assertTrue(readyChannels.contains("chan1"));
+        assertTrue(readyChannels.contains("chan2"));
+    }
+
+    @Test
+    public void testFindUnroutedDataCreateTimeRangeByChannelWithGapsMapsChannelDataCreateTimeRanges() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        testRouterService.gapDetector = mock(DataGapDetector.class);
+        when(testRouterService.gapDetector.getDataGaps()).thenReturn(Arrays.asList(new DataGap(1, 10)));
+        Date minTime = new Date(1000L);
+        Date maxTime = new Date(2000L);
+        Row row = new Row(3);
+        row.put("channel_id", "chan1");
+        row.put("min_create_time", minTime);
+        row.put("max_create_time", maxTime);
+        stubQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
+        List<ChannelDataCreateTimeRange> ranges = testRouterService.findUnroutedDataCreateTimeRangeByChannel();
+        assertEquals(1, ranges.size());
+        assertEquals("chan1", ranges.get(0).channelId());
+        assertEquals(minTime, ranges.get(0).minCreateTime());
+        assertEquals(maxTime, ranges.get(0).maxCreateTime());
     }
 
     @Test

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -40,10 +40,13 @@ import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.common.ParameterConstants;
+import org.jumpmind.symmetric.common.TableConstants;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.model.Channel;
 import org.jumpmind.symmetric.model.Data;
+import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.Node;
 import org.jumpmind.symmetric.model.NodeChannel;
 import org.jumpmind.symmetric.model.NodeGroupLink;
@@ -352,5 +355,57 @@ public class RouterServiceTest {
 
     private ChannelRouterContext newContext(NodeChannel channel) {
         return new ChannelRouterContext(SOURCE_NODE_GROUP, channel, mock(ISqlTransaction.class), null);
+    }
+
+    private RouterService newRouterServiceForGapQuery(IParameterService parameterService, int maxGapsToQualify, int maxGapsBeforeGreaterThanQuery) {
+        ISymmetricEngine engine = mock(ISymmetricEngine.class);
+        ISymmetricDialect symmetricDialect = mock(ISymmetricDialect.class);
+        IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
+        when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        when(databasePlatform.scrubSql(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(parameterService.getTablePrefix()).thenReturn("sym");
+        when(parameterService.getInt(ParameterConstants.ROUTING_MAX_GAPS_TO_QUALIFY_IN_SQL, 100)).thenReturn(maxGapsToQualify);
+        when(parameterService.getInt(ParameterConstants.ROUTING_DATA_READER_THRESHOLD_GAPS_TO_USE_GREATER_QUERY, 100))
+                .thenReturn(maxGapsBeforeGreaterThanQuery);
+        when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
+        when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
+        when(engine.getExtensionService()).thenReturn(mock(IExtensionService.class));
+        RouterService testRouterService = new RouterService(engine);
+        testRouterService.setSqlMap(new RouterServiceSqlMap(databasePlatform,
+                Collections.singletonMap("data", TableConstants.getTableName("sym", TableConstants.SYM_DATA))));
+        return testRouterService;
+    }
+
+    @Test
+    public void testBuildGapQualifiedQueryUsesGapRangeSqlWhenGapCountAtOrBelowThreshold() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
+        RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
+                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
+        assertTrue(query.sql().contains("group by channel_id"));
+        assertTrue(query.sql().contains("data_id between ? and ?"));
+        assertEquals(4, query.args().length);
+        assertEquals(1L, query.args()[0]);
+        assertEquals(10L, query.args()[1]);
+        assertEquals(20L, query.args()[2]);
+        assertEquals(30L, query.args()[3]);
+    }
+
+    @Test
+    public void testBuildGapQualifiedQueryUsesStartIdSqlWhenGapCountExceedsThreshold() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 1);
+        List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
+        RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
+                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
+        assertTrue(query.sql().contains("data_id >= ?"));
+        assertEquals(1, query.args().length);
+        assertEquals(1L, query.args()[0]);
+    }
+
+    @Test
+    public void testFindUnroutedDataCreateTimeRangeByChannelReturnsEmptyListWhenGapsNotYetDetected() {
+        assertEquals(Collections.emptyList(), routerService.findUnroutedDataCreateTimeRangeByChannel());
     }
 }

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -369,7 +369,8 @@ public class RouterServiceTest {
         IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(databasePlatform.scrubSql(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        when(databasePlatform.getSqlTemplateDirty()).thenReturn(mock(ISqlTemplate.class));
+        ISqlTemplate sqlTemplate = mock(ISqlTemplate.class);
+        when(databasePlatform.getSqlTemplateDirty()).thenReturn(sqlTemplate);
         when(parameterService.getTablePrefix()).thenReturn("sym");
         when(parameterService.getInt(ParameterConstants.ROUTING_MAX_GAPS_TO_QUALIFY_IN_SQL, 100)).thenReturn(maxGapsToQualify);
         when(parameterService.getInt(ParameterConstants.ROUTING_DATA_READER_THRESHOLD_GAPS_TO_USE_GREATER_QUERY, 100))

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -388,7 +388,7 @@ public class RouterServiceTest {
     }
 
     @Test
-    public void testBuildGapQualifiedQueryUsesGapRangeSqlWhenGapCountAtOrBelowThreshold() {
+    void testBuildGapQualifiedQueryUsesGapRangeSqlWhenGapCountAtOrBelowThreshold() {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
         List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
         RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
@@ -403,7 +403,7 @@ public class RouterServiceTest {
     }
 
     @Test
-    public void testBuildGapQualifiedQueryUsesStartIdSqlWhenGapCountExceedsThreshold() {
+    void testBuildGapQualifiedQueryUsesStartIdSqlWhenGapCountExceedsThreshold() {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 1);
         List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
         RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
@@ -426,7 +426,7 @@ public class RouterServiceTest {
     }
 
     @Test
-    public void testGetReadyChannelsMapsChannelIdsFromQueryResults() {
+    void testGetReadyChannelsMapsChannelIdsFromQueryResults() {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
         testRouterService.gapDetector = mock(DataGapDetector.class);
         when(testRouterService.gapDetector.getDataGaps()).thenReturn(Arrays.asList(new DataGap(1, 10)));
@@ -439,7 +439,7 @@ public class RouterServiceTest {
     }
 
     @Test
-    public void testFindUnroutedDataCreateTimeRangeByChannelWithGapsMapsChannelDataCreateTimeRanges() {
+    void testFindUnroutedDataCreateTimeRangeByChannelWithGapsMapsChannelDataCreateTimeRanges() {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
         testRouterService.gapDetector = mock(DataGapDetector.class);
         when(testRouterService.gapDetector.getDataGaps()).thenReturn(Arrays.asList(new DataGap(1, 10)));
@@ -458,7 +458,7 @@ public class RouterServiceTest {
     }
 
     @Test
-    public void testFindUnroutedDataCreateTimeRangeByChannelReturnsEmptyListWhenGapsNotYetDetected() {
+    void testFindUnroutedDataCreateTimeRangeByChannelReturnsEmptyListWhenGapsNotYetDetected() {
         assertEquals(Collections.emptyList(), routerService.findUnroutedDataCreateTimeRangeByChannel());
     }
 }

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
@@ -210,11 +210,19 @@ public class MockStatisticManager implements IStatisticManager {
     }
 
     @Override
-    public void updateDataMinCreateTime(String channelId, Date minCreateTime) {
+    public void updateDataRoutedMinCreateTime(String channelId, Date minCreateTime) {
     }
 
     @Override
-    public void updateDataMaxCreateTime(String channelId, Date maxCreateTime) {
+    public void updateDataRoutedMaxCreateTime(String channelId, Date maxCreateTime) {
+    }
+
+    @Override
+    public void setDataUnroutedMinCreateTime(String channelId, Date minCreateTime) {
+    }
+
+    @Override
+    public void setDataUnroutedMaxCreateTime(String channelId, Date maxCreateTime) {
     }
 
     @Override

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
@@ -219,10 +219,12 @@ public class MockStatisticManager implements IStatisticManager {
 
     @Override
     public void setDataUnroutedMinCreateTime(String channelId, Date minCreateTime) {
+        // no-op: this mock does not track metric gauge state
     }
 
     @Override
     public void setDataUnroutedMaxCreateTime(String channelId, Date maxCreateTime) {
+        // no-op: this mock does not track metric gauge state
     }
 
     @Override

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/StatisticManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/StatisticManagerTest.java
@@ -522,10 +522,10 @@ class StatisticManagerTest {
     }
 
     @Test
-    void updateDataMaxCreateTime_updatesChannelStats() {
+    void updateDataRoutedMaxCreateTime_updatesChannelStats() {
         when(nodeService.getCachedIdentity()).thenReturn(node("node1"));
         Date maxTime = new Date();
-        manager.updateDataMaxCreateTime("chan1", maxTime);
+        manager.updateDataRoutedMaxCreateTime("chan1", maxTime);
         assertEquals(maxTime, manager.getWorkingChannelStats().get("chan1").getDataMaxCreateTime());
     }
 
@@ -804,16 +804,66 @@ class StatisticManagerTest {
     }
 
     @Test
-    void updateDataMinCreateTime_withNonNullMetricsGauge_invokesGaugeSetValue() {
+    void updateDataRoutedMinCreateTime_withNonNullMetricsGauge_doesNotInvokeGauge() {
         IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
         ISymLongGauge gauge = mock(ISymLongGauge.class);
         when(engine.getMetricsService()).thenReturn(metricsService);
         when(metricsService.registerLongGauge(anyString(), any())).thenReturn(gauge);
         when(nodeService.getCachedIdentity()).thenReturn(node("node1"));
         Date minTime = new Date();
-        manager.updateDataMinCreateTime("chan1", minTime);
+        manager.updateDataRoutedMinCreateTime("chan1", minTime);
         assertEquals(minTime, manager.getWorkingChannelStats().get("chan1").getDataMinCreateTime());
+        verify(gauge, never()).setValue(anyLong());
+    }
+
+    @Test
+    void setDataUnRoutedMinCreateTime_withNonNullMetricsGauge_invokesGaugeSetValue() {
+        IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
+        ISymLongGauge gauge = mock(ISymLongGauge.class);
+        when(engine.getMetricsService()).thenReturn(metricsService);
+        when(metricsService.registerLongGauge(anyString(), any())).thenReturn(gauge);
+        Date minTime = new Date();
+        manager.setDataUnroutedMinCreateTime("chan1", minTime);
         verify(gauge).setValue(minTime.getTime());
+    }
+
+    @Test
+    void setDataUnRoutedMaxCreateTime_withNonNullMetricsGauge_invokesGaugeSetValue() {
+        IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
+        ISymLongGauge gauge = mock(ISymLongGauge.class);
+        when(engine.getMetricsService()).thenReturn(metricsService);
+        when(metricsService.registerLongGauge(anyString(), any())).thenReturn(gauge);
+        Date maxTime = new Date();
+        manager.setDataUnroutedMaxCreateTime("chan1", maxTime);
+        verify(gauge).setValue(maxTime.getTime());
+    }
+
+    @Test
+    void setDataUnRoutedMinCreateTime_calledTwice_bothValuesReachGauge() {
+        IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
+        ISymLongGauge gauge = mock(ISymLongGauge.class);
+        when(engine.getMetricsService()).thenReturn(metricsService);
+        when(metricsService.registerLongGauge(anyString(), any())).thenReturn(gauge);
+        Date earlierTime = new Date(1000L);
+        Date laterTime = new Date(2000L);
+        manager.setDataUnroutedMinCreateTime("chan1", earlierTime);
+        manager.setDataUnroutedMinCreateTime("chan1", laterTime);
+        verify(gauge).setValue(earlierTime.getTime());
+        verify(gauge).setValue(laterTime.getTime());
+    }
+
+    @Test
+    void setDataUnRoutedMaxCreateTime_calledTwice_bothValuesReachGauge() {
+        IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
+        ISymLongGauge gauge = mock(ISymLongGauge.class);
+        when(engine.getMetricsService()).thenReturn(metricsService);
+        when(metricsService.registerLongGauge(anyString(), any())).thenReturn(gauge);
+        Date laterTime = new Date(2000L);
+        Date earlierTime = new Date(1000L);
+        manager.setDataUnroutedMaxCreateTime("chan1", laterTime);
+        manager.setDataUnroutedMaxCreateTime("chan1", earlierTime);
+        verify(gauge).setValue(laterTime.getTime());
+        verify(gauge).setValue(earlierTime.getTime());
     }
 
     @Test


### PR DESCRIPTION
The problem was that the `rows.create.time.min` and `rows.create.time.max` metrics are supposed to track the create times of unrouted data (according to their documentation), but instead they were tracking routed data. This is because their statistics were populated the same way as the `data_min_create_time` and `data_max_create_time` columns in `sym_node_host_channel_stats`, which track routed data.

To make this distinction clear, I added new `setDataUnroutedMinCreateTime()` and `setDataUnroutedMaxCreateTime()` methods to `IStatisticManager`, renamed the existing methods for routed data, and added comments to clarify what each method does.

It can be expensive to query for unrouted data, so having the Routing job run these queries would be impractical. Instead, I added a new `RefreshDataCreateTimeMetricsJob` to query the unrouted data and record the correct statistics. I followed the example of the existing `RefreshBacklogReportJob`, which also runs potentially expensive queries for metrics every 15 minutes.