### PR TITLE
SYM-7722: Fixed rows.unrouted.channel.count metric not getting updated

### DIFF
--- a/symmetric-assemble/src/asciidoc/installation.ad
+++ b/symmetric-assemble/src/asciidoc/installation.ad
@@ -675,7 +675,7 @@ The following environment variables control whether a given SymmetricDS job is a
 |SYM_START_PURGE_INCOMING_JOB|start.purge.incoming.job|true
 |SYM_START_PURGE_METRIC_STATS_JOB|start.purge.metric.stats.job|true
 |SYM_START_REFRESH_BACKLOG_REPORT_JOB|start.refresh.backlog.report.job|true
-|SYM_START_REFRESH_DATA_CREATE_TIME_METRICS_JOB|start.refresh.data.create.time.metrics.job|true
+|SYM_START_REFRESH_UNROUTED_DATA_METRICS_JOB|start.refresh.unrouted.data.metrics.job|true
 |SYM_START_HEARTBEAT_JOB|start.heartbeat.job|true
 |SYM_START_SYNCTRIGGERS_JOB|start.synctriggers.job|true
 |SYM_START_SYNC_CONFIG_JOB|start.sync.config.job|true

--- a/symmetric-assemble/src/asciidoc/manage/jobs.ad
+++ b/symmetric-assemble/src/asciidoc/manage/jobs.ad
@@ -149,10 +149,13 @@ The Refresh Backlog Report Job queries <<OUTGOING_BATCH>> and <<INCOMING_BATCH>>
 ifdef::pro[]
 Also, this job saves a snapshot of the outgoing backlog to the <<ANALYTICS_REPORT>> table, which is displayed under the Analytics tab.
 
-==== Refresh Data Create Time Metrics Job
+==== Refresh Unrouted Data Metrics Job
 
-The Refresh Data Create Time Metrics Job queries <<DATA>> for the oldest and most recent create time of unrouted
+The Refresh Unrouted Data Metrics Job queries <<DATA>> for the oldest and most recent create time of unrouted
 rows, grouped by channel, to update the `rows.create.time.min` and `rows.create.time.max` metrics.
+
+When `routing.collect.stats.unrouted` is enabled, this job also counts unrouted rows per channel to update the
+`rows.unrouted.channel.count` metric and the `sym_node_host_channel_stats.data_unrouted` column.
 
 ==== Compare Job
 

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/job/BuiltInJobs.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/job/BuiltInJobs.java
@@ -50,7 +50,7 @@ public class BuiltInJobs {
         builtInJobs.add(new StatisticFlushJob(engine, taskScheduler));
         builtInJobs.add(new PurgeMetricStatsJob(engine, taskScheduler));
         builtInJobs.add(createJob(RefreshBacklogReportJob.class, engine, taskScheduler));
-        builtInJobs.add(createJob(RefreshDataCreateTimeMetricsJob.class, engine, taskScheduler));
+        builtInJobs.add(createJob(RefreshUnroutedDataMetricsJob.class, engine, taskScheduler));
         builtInJobs.add(new SyncTriggersJob(engine, taskScheduler));
         builtInJobs.add(new HeartbeatJob(engine, taskScheduler));
         builtInJobs.add(new WatchdogJob(engine, taskScheduler));

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/job/RefreshUnroutedDataMetricsJob.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/job/RefreshUnroutedDataMetricsJob.java
@@ -22,22 +22,28 @@ package org.jumpmind.symmetric.job;
 
 import static org.jumpmind.symmetric.job.JobDefaults.EVERY_FIFTEEN_MINUTES;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.model.ChannelDataUnroutedCount;
+import org.jumpmind.symmetric.model.NodeChannel;
 import org.jumpmind.symmetric.service.ClusterConstants;
 import org.jumpmind.symmetric.statistic.IStatisticManager;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-public class RefreshDataCreateTimeMetricsJob extends AbstractJob {
-    public RefreshDataCreateTimeMetricsJob(ISymmetricEngine engine, ThreadPoolTaskScheduler taskScheduler) {
-        super(ClusterConstants.REFRESH_DATA_CREATE_TIME_METRICS, engine, taskScheduler);
+public class RefreshUnroutedDataMetricsJob extends AbstractJob {
+    public RefreshUnroutedDataMetricsJob(ISymmetricEngine engine, ThreadPoolTaskScheduler taskScheduler) {
+        super(ClusterConstants.REFRESH_UNROUTED_DATA_METRICS, engine, taskScheduler);
     }
 
     @Override
     public JobDefaults getDefaults() {
         return new JobDefaults()
                 .schedule(EVERY_FIFTEEN_MINUTES)
-                .description("Refresh unrouted data create time metrics");
+                .description("Refresh unrouted data create time and row count metrics");
     }
 
     @Override
@@ -56,6 +62,17 @@ public class RefreshDataCreateTimeMetricsJob extends AbstractJob {
         for (ChannelDataCreateTimeRange range : engine.getRouterService().findUnroutedDataCreateTimeRangeByChannel()) {
             statisticManager.setDataUnroutedMinCreateTime(range.channelId(), range.minCreateTime());
             statisticManager.setDataUnroutedMaxCreateTime(range.channelId(), range.maxCreateTime());
+        }
+        if (engine.getParameterService().is(ParameterConstants.ROUTING_COLLECT_STATS_UNROUTED)) {
+            refreshUnroutedDataCounts(statisticManager);
+        }
+    }
+
+    private void refreshUnroutedDataCounts(IStatisticManager statisticManager) {
+        Map<String, Long> countsByChannel = engine.getRouterService().findUnroutedDataCountByChannel().stream()
+                .collect(Collectors.toMap(ChannelDataUnroutedCount::channelId, ChannelDataUnroutedCount::count));
+        for (NodeChannel channel : engine.getConfigurationService().getNodeChannels(false)) {
+            statisticManager.setDataUnRouted(channel.getChannelId(), countsByChannel.getOrDefault(channel.getChannelId(), 0L));
         }
     }
 }

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/job/RefreshUnroutedDataMetricsJobTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/job/RefreshUnroutedDataMetricsJobTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,7 +37,11 @@ import java.util.Date;
 import java.util.List;
 
 import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.model.ChannelDataUnroutedCount;
+import org.jumpmind.symmetric.model.NodeChannel;
+import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IParameterService;
 import org.jumpmind.symmetric.service.IRouterService;
 import org.jumpmind.symmetric.statistic.IStatisticManager;
@@ -44,10 +49,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-class RefreshDataCreateTimeMetricsJobTest {
+class RefreshUnroutedDataMetricsJobTest {
     private ISymmetricEngine engine;
     private IParameterService parameterService;
     private IRouterService routerService;
+    private IConfigurationService configurationService;
     private IStatisticManager statisticManager;
     private ThreadPoolTaskScheduler taskScheduler;
 
@@ -56,17 +62,20 @@ class RefreshDataCreateTimeMetricsJobTest {
         engine = mock(ISymmetricEngine.class);
         parameterService = mock(IParameterService.class);
         routerService = mock(IRouterService.class);
+        configurationService = mock(IConfigurationService.class);
         statisticManager = mock(IStatisticManager.class);
         taskScheduler = mock(ThreadPoolTaskScheduler.class);
         when(engine.getParameterService()).thenReturn(parameterService);
         when(parameterService.getExternalId()).thenReturn("test-node");
         when(parameterService.getInt(anyString())).thenReturn(10000);
         when(engine.getRouterService()).thenReturn(routerService);
+        when(engine.getConfigurationService()).thenReturn(configurationService);
         when(engine.getStatisticManager()).thenReturn(statisticManager);
+        when(routerService.findUnroutedDataCreateTimeRangeByChannel()).thenReturn(Collections.emptyList());
     }
 
-    private RefreshDataCreateTimeMetricsJob newJob() {
-        return new RefreshDataCreateTimeMetricsJob(engine, taskScheduler);
+    private RefreshUnroutedDataMetricsJob newJob() {
+        return new RefreshUnroutedDataMetricsJob(engine, taskScheduler);
     }
 
     @Test
@@ -126,5 +135,36 @@ class RefreshDataCreateTimeMetricsJobTest {
         verify(statisticManager).setDataUnroutedMaxCreateTime("chan1", maxTime1);
         verify(statisticManager).setDataUnroutedMinCreateTime("chan2", minTime2);
         verify(statisticManager).setDataUnroutedMaxCreateTime("chan2", maxTime2);
+    }
+
+    @Test
+    void doJob_collectStatsUnroutedDisabled_noSetDataUnRoutedCalls() throws Exception {
+        when(parameterService.is(ParameterConstants.ROUTING_COLLECT_STATS_UNROUTED)).thenReturn(false);
+        newJob().doJob(false);
+        verify(routerService, never()).findUnroutedDataCountByChannel();
+        verify(statisticManager, never()).setDataUnRouted(any(), anyLong());
+    }
+
+    @Test
+    void doJob_collectStatsUnroutedEnabled_setsRealCountAndZeroesAbsentChannels() throws Exception {
+        when(parameterService.is(ParameterConstants.ROUTING_COLLECT_STATS_UNROUTED)).thenReturn(true);
+        when(configurationService.getNodeChannels(false)).thenReturn(
+                List.of(new NodeChannel("chan1"), new NodeChannel("chan2")));
+        when(routerService.findUnroutedDataCountByChannel())
+                .thenReturn(List.of(new ChannelDataUnroutedCount("chan1", 7L)));
+        newJob().doJob(false);
+        verify(statisticManager).setDataUnRouted("chan1", 7L);
+        verify(statisticManager).setDataUnRouted("chan2", 0L);
+    }
+
+    @Test
+    void doJob_collectStatsUnroutedEnabled_emptyResult_zeroesAllConfiguredChannels() throws Exception {
+        when(parameterService.is(ParameterConstants.ROUTING_COLLECT_STATS_UNROUTED)).thenReturn(true);
+        when(configurationService.getNodeChannels(false)).thenReturn(
+                List.of(new NodeChannel("chan1"), new NodeChannel("chan2")));
+        when(routerService.findUnroutedDataCountByChannel()).thenReturn(Collections.emptyList());
+        newJob().doJob(false);
+        verify(statisticManager).setDataUnRouted("chan1", 0L);
+        verify(statisticManager).setDataUnRouted("chan2", 0L);
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -73,7 +73,7 @@ final public class ParameterConstants {
     public static final String START_OFFLINE_PUSH_JOB = "start.offline.push.job";
     public static final String START_REFRESH_CACHE_JOB = "start.refresh.cache.job";
     public static final String START_REFRESH_BACKLOG_REPORT_JOB = "start.refresh.backlog.report.job";
-    public static final String START_REFRESH_DATA_CREATE_TIME_METRICS_JOB = "start.refresh.data.create.time.metrics.job";
+    public static final String START_REFRESH_UNROUTED_DATA_METRICS_JOB = "start.refresh.unrouted.data.metrics.job";
     public static final String START_FILE_SYNC_TRACKER_JOB = "start.file.sync.tracker.job";
     public static final String START_FILE_SYNC_PUSH_JOB = "start.file.sync.push.job";
     public static final String START_FILE_SYNC_PULL_JOB = "start.file.sync.pull.job";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ChannelDataUnroutedCount.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ChannelDataUnroutedCount.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.model;
+
+/**
+ * One row from a query of {@code sym_data} joined against open {@code sym_data_gap} entries: the count of unrouted rows for a channel.
+ */
+public record ChannelDataUnroutedCount(String channelId, long count) {
+}

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/observability/interfaces/IEngineMetricsService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/observability/interfaces/IEngineMetricsService.java
@@ -51,6 +51,13 @@ public interface IEngineMetricsService extends IMetricsService {
      */
     ISymDoubleGauge getDoubleGauge(String metricId, MetricAttributeList attrs);
 
+    /**
+     * Registers (or returns the existing) double gauge for {@code metricId} with the given attributes. The definition must already be registered in
+     * {@code MetricDefinitionFactory}; throws {@code InvalidMetricDataException} if it is not. Never pass an inline definition — all built-in metric
+     * definitions must be declared and registered exclusively in {@code MetricDefinitionFactory}.
+     */
+    ISymDoubleGauge registerDoubleGauge(String metricId, MetricAttributeList attrs);
+
     IUpDownCounter registerUpDownCounter(ISymMetricDefinition definition);
 
     IUpDownCounter registerUpDownCounter(ISymMetricDefinition definition, MetricAttributeList attrs);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
@@ -61,7 +61,7 @@ public class ClusterConstants {
     public static final String LOG_MINER = "Log Miner";
     public static final String REFRESH_ANALYTICS = "Refresh Analytics";
     public static final String REFRESH_BACKLOG_REPORT = "Refresh Backlog Report";
-    public static final String REFRESH_DATA_CREATE_TIME_METRICS = "Refresh Data Create Time Metrics";
+    public static final String REFRESH_UNROUTED_DATA_METRICS = "Refresh Unrouted Data Metrics";
     public static final String JUMPMIND_TOKEN_REFRESH = "Jumpmind Token Refresh";
     public static final String FILE_SYNC_SHARED = "FILE_SYNC_SHARED";
     public static final String TYPE_CLUSTER = "CLUSTER";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IRouterService.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.model.ChannelDataUnroutedCount;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.DataMetaData;
 import org.jumpmind.symmetric.model.Node;
@@ -44,6 +45,8 @@ public interface IRouterService extends IService {
     public long getUnroutedDataCount();
 
     public List<ChannelDataCreateTimeRange> findUnroutedDataCreateTimeRangeByChannel();
+
+    public List<ChannelDataUnroutedCount> findUnroutedDataCountByChannel();
 
     public boolean shouldDataBeRouted(SimpleRouterContext context, DataMetaData dataMetaData,
             Node node, boolean initialLoad, boolean initialLoadSelectUsed, TriggerRouter triggerRouter);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -60,6 +60,7 @@ import org.jumpmind.symmetric.io.data.ProtocolException;
 import org.jumpmind.symmetric.model.AbstractBatch.Status;
 import org.jumpmind.symmetric.model.Channel;
 import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.model.ChannelDataUnroutedCount;
 import org.jumpmind.symmetric.model.Data;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.DataMetaData;
@@ -408,6 +409,11 @@ public class RouterService extends AbstractService implements IRouterService, IN
                 row.getDateTime("min_create_time"), row.getDateTime("max_create_time")), query.args(), query.types());
     }
 
+    public List<ChannelDataUnroutedCount> findUnroutedDataCountByChannel() {
+        return sqlTemplateDirty.query(getSql("selectChannelDataUnroutedCountSql"),
+                (Row row) -> new ChannelDataUnroutedCount(row.getString("channel_id"), row.getLong("unrouted_count")));
+    }
+
     protected GapQualifiedQuery buildGapQualifiedQuery(List<DataGap> dataGaps, String gapsSqlKey, String startIdSqlKey) {
         int dataIdSqlType = engine.getSymmetricDialect().getSqlTypeForIds();
         int numberOfGapsToQualify = parameterService.getInt(ParameterConstants.ROUTING_MAX_GAPS_TO_QUALIFY_IN_SQL, 100);
@@ -685,21 +691,6 @@ public class RouterService extends AbstractService implements IRouterService, IN
                     context.clearDataEventsList();
                     context.incrementStat(System.currentTimeMillis() - insertTs, ChannelRouterContext.STAT_INSERT_DATA_EVENTS_MS);
                     completeBatchesAndCommit(context);
-                    if (parameterService.is(ParameterConstants.ROUTING_COLLECT_STATS_UNROUTED)) {
-                        Data lastDataProcessed = context.getLastDataProcessed();
-                        if (lastDataProcessed != null && lastDataProcessed.getDataId() > 0) {
-                            String channelId = nodeChannel.getChannelId();
-                            long queryTs = System.currentTimeMillis();
-                            long dataLeftToRoute = sqlTemplate.queryForInt(
-                                    getSql("selectUnroutedCountForChannelSql"), channelId,
-                                    lastDataProcessed.getDataId());
-                            queryTs = System.currentTimeMillis() - queryTs;
-                            if (queryTs > Constants.LONG_OPERATION_THRESHOLD) {
-                                log.warn("Unrouted query for channel {} took longer than expected. The query took {} ms.", channelId, queryTs);
-                            }
-                            engine.getStatisticManager().setDataUnRouted(channelId, dataLeftToRoute);
-                        }
-                    }
                 }
                 if (context != null) {
                     hasMaxDataRoutedByChannel.put(nodeChannel.getChannelId(), context.getCommittedDataIdCount() >= context.getChannel().getMaxDataToRoute());

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
@@ -35,6 +35,10 @@ public class RouterServiceSqlMap extends AbstractSqlMap {
         putSql("selectChannelDataCreateTimeRangeUsingStartDataId",
                 "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
                         + "from $(data) where data_id >= ? group by channel_id");
+        putSql("selectChannelDataUnroutedCountSql",
+                "select d.channel_id, count(*) as unrouted_count from $(data) d "
+                        + "where exists (select 1 from $(data_gap) g where g.is_expired = 0 and d.data_id between g.start_id and g.end_id) "
+                        + "group by d.channel_id");
         putSql("selectDataUsingGapsSql",
                 "select $(selectDataUsingGapsSqlHint) d.data_id, d.table_name, d.event_type, d.row_data as row_data, d.pk_data as pk_data, d.old_data as old_data, "
                         + " d.create_time, d.trigger_hist_id, d.channel_id, d.transaction_id, d.source_node_id, d.external_data, d.node_list, d.is_prerouted "
@@ -47,7 +51,6 @@ public class RouterServiceSqlMap extends AbstractSqlMap {
         putSql("orderByCreateTime", " order by d.create_time asc, d.data_id asc ");
         putSql("selectDistinctDataIdFromDataEventUsingGapsSql",
                 "select distinct data_id from $(data_event) where data_id >=? and data_id <= ? order by data_id asc ");
-        putSql("selectUnroutedCountForChannelSql", "select count(*) from $(data) where channel_id=? and data_id >=? ");
         putSql("selectLastDataIdRoutedUsingDataGapSql", "select max(start_id) from $(data_gap) ");
         putSql("selectOracleNextValueSql", "select nextvalue from gv$_sequences where sequence_name = ?");
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
@@ -36,9 +36,9 @@ public class RouterServiceSqlMap extends AbstractSqlMap {
                 "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
                         + "from $(data) where data_id >= ? group by channel_id");
         putSql("selectChannelDataUnroutedCountSql",
-                "select d.channel_id, count(*) as unrouted_count from $(data) d "
-                        + "where exists (select 1 from $(data_gap) g where g.is_expired = 0 and d.data_id between g.start_id and g.end_id) "
-                        + "group by d.channel_id");
+                "select d.channel_id, count(*) as unrouted_count from $(data_gap) g "
+                        + "join $(data) d on d.data_id between g.start_id and g.end_id "
+                        + "where g.is_expired = 0 group by d.channel_id");
         putSql("selectDataUsingGapsSql",
                 "select $(selectDataUsingGapsSqlHint) d.data_id, d.table_name, d.event_type, d.row_data as row_data, d.pk_data as pk_data, d.old_data as old_data, "
                         + " d.create_time, d.trigger_hist_id, d.channel_id, d.transaction_id, d.source_node_id, d.external_data, d.node_list, d.is_prerouted "

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -955,7 +955,7 @@ public class StatisticManager implements IStatisticManager {
             IEngineMetricsService svc = engine.getMetricsService();
             if (svc == null)
                 return;
-            ISymDoubleGauge g = svc.getDoubleGauge(metricId, MetricAttributeList.of(new MetricAttribute(CHANNEL, channelId)));
+            ISymDoubleGauge g = svc.registerDoubleGauge(metricId, MetricAttributeList.of(new MetricAttribute(CHANNEL, channelId)));
             if (g != null)
                 g.setValue(value);
         } catch (Exception e) {

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -1595,11 +1595,11 @@ job.purge.metric.stats.cron=0 0 0 * * *
 # Tags: jobs
 job.refresh.backlog.report.period.time.ms=900000
 
-# This is how often the refresh data create time metrics job will run.
+# This is how often the refresh unrouted data metrics job will run.
 #
 # DatabaseOverridable: true
 # Tags: jobs
-job.refresh.data.create.time.metrics.period.time.ms=900000
+job.refresh.unrouted.data.metrics.period.time.ms=900000
 
 # This is when the sync triggers job will run.
 #
@@ -1745,11 +1745,11 @@ start.purge.metric.stats.job=true
 # Type: boolean
 start.refresh.backlog.report.job=true
 
-# Whether the refresh data create time metrics job is enabled for this node.
+# Whether the refresh unrouted data metrics job is enabled for this node.
 #
 # Tags: jobs
 # Type: boolean
-start.refresh.data.create.time.metrics.job=true
+start.refresh.unrouted.data.metrics.job=true
 
 # Whether the heartbeat job is enabled for this node.  The heartbeat job simply
 # inserts an event to update the heartbeat_time column on the node_host table for the current node.
@@ -1965,11 +1965,13 @@ routing.data.reader.use.multiple.queries=false
 # Tags: routing
 routing.log.stats.on.batch.error=false
 
-# Enable to collect unrouted data statistics into the stat tables for graphs.
+# Enable to have the Refresh Data Create Time Metrics job collect unrouted row
+# counts per channel, updating sym_node_host_channel_stats.data_unrouted and
+# the rows.unrouted.channel.count metric.
 #
 # DatabaseOverridable: true
 # Tags: routing
-routing.collect.stats.unrouted=false
+routing.collect.stats.unrouted=true
 
 # Enable to query for which channels have data waiting, and then only route for those channels.
 #

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -50,6 +50,7 @@ import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.model.Channel;
 import org.jumpmind.symmetric.model.ChannelDataCreateTimeRange;
+import org.jumpmind.symmetric.model.ChannelDataUnroutedCount;
 import org.jumpmind.symmetric.model.Data;
 import org.jumpmind.symmetric.model.DataGap;
 import org.jumpmind.symmetric.model.Node;
@@ -460,5 +461,44 @@ public class RouterServiceTest {
     @Test
     void testFindUnroutedDataCreateTimeRangeByChannelReturnsEmptyListWhenGapsNotYetDetected() {
         assertEquals(Collections.emptyList(), routerService.findUnroutedDataCreateTimeRangeByChannel());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stubNoArgQueryToInvokeMapper(ISqlTemplate sqlTemplate, List<Row> rows) {
+        when(sqlTemplate.query(any(), any(ISqlRowMapper.class))).thenAnswer(invocation -> {
+            ISqlRowMapper<Object> mapper = invocation.getArgument(1);
+            List<Object> results = new ArrayList<>();
+            for (Row row : rows) {
+                results.add(mapper.mapRow(row));
+            }
+            return results;
+        });
+    }
+
+    @Test
+    void testFindUnroutedDataCountByChannelMapsChannelDataUnroutedCounts() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        Row row = new Row(2);
+        row.put("channel_id", "chan1");
+        row.put("unrouted_count", 5L);
+        stubNoArgQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
+        List<ChannelDataUnroutedCount> counts = testRouterService.findUnroutedDataCountByChannel();
+        assertEquals(1, counts.size());
+        assertEquals("chan1", counts.get(0).channelId());
+        assertEquals(5L, counts.get(0).count());
+    }
+
+    @Test
+    void testFindUnroutedDataCountByChannelIgnoresGapDetectorState() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        testRouterService.gapDetector = mock(DataGapDetector.class);
+        when(testRouterService.gapDetector.getDataGaps()).thenReturn(Collections.emptyList());
+        Row row = new Row(2);
+        row.put("channel_id", "chan1");
+        row.put("unrouted_count", 5L);
+        stubNoArgQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
+        List<ChannelDataUnroutedCount> counts = testRouterService.findUnroutedDataCountByChannel();
+        assertEquals(1, counts.size());
+        assertEquals("chan1", counts.get(0).channelId());
     }
 }

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/StatisticManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/StatisticManagerTest.java
@@ -796,11 +796,23 @@ class StatisticManagerTest {
         IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
         ISymDoubleGauge gauge = mock(ISymDoubleGauge.class);
         when(engine.getMetricsService()).thenReturn(metricsService);
-        when(metricsService.getDoubleGauge(anyString(), any())).thenReturn(gauge);
+        when(metricsService.registerDoubleGauge(anyString(), any())).thenReturn(gauge);
         when(nodeService.getCachedIdentity()).thenReturn(node("node1"));
         manager.setDataUnRouted("chan1", 10L);
         assertEquals(10L, manager.getWorkingChannelStats().get("chan1").getDataUnRouted());
         verify(gauge).setValue(10.0);
+    }
+
+    @Test
+    void setDataUnRouted_withZeroCount_clearsGaugeToZero() {
+        IEngineMetricsService metricsService = mock(IEngineMetricsService.class);
+        ISymDoubleGauge gauge = mock(ISymDoubleGauge.class);
+        when(engine.getMetricsService()).thenReturn(metricsService);
+        when(metricsService.registerDoubleGauge(anyString(), any())).thenReturn(gauge);
+        when(nodeService.getCachedIdentity()).thenReturn(node("node1"));
+        manager.setDataUnRouted("chan1", 0L);
+        assertEquals(0L, manager.getWorkingChannelStats().get("chan1").getDataUnRouted());
+        verify(gauge).setValue(0.0);
     }
 
     @Test

--- a/symmetric-stats/src/main/java/org/jumpmind/symmetric/observability/metrics/AbstractMetricsService.java
+++ b/symmetric-stats/src/main/java/org/jumpmind/symmetric/observability/metrics/AbstractMetricsService.java
@@ -187,6 +187,10 @@ abstract class AbstractMetricsService implements IMetricsService {
         return m instanceof ISymDoubleGauge g ? g : null;
     }
 
+    public ISymDoubleGauge registerDoubleGauge(String metricId, MetricAttributeList attrs) {
+        return registerDoubleGauge(metricsManager.getMetricDefinitionFactory().getDefinition(metricId), attrs);
+    }
+
     public ISymLongGauge registerLongGauge(String metricId, MetricAttributeList attrs) {
         return registerLongGauge(metricsManager.getMetricDefinitionFactory().getDefinition(metricId), attrs);
     }


### PR DESCRIPTION
There were 2 problems to fix:

1. The `rows.unrouted.channel.count` metric has no stats for custom channels
2. The `rows.unrouted.channel.count` doesn't track unrouted data for disabled channels

To fix problem 1, I took a similar approach to what I did for SYM-7725 and added an `IEngineMetricsService.registerDoubleGauge()` method which adds a new channel rather than skipping it because it doesn't exist.

To fix problem 2, I added a new `IRouterService.findUnroutedDataCountByChannel()` method to retrieve the unrouted data count per channel, including disabled channels. I had `RefreshDataCreateTimeMetricsJob` run this query and renamed it to `RefreshUnroutedDataMetricsJob` because it now covers more than just the create time metrics. I made sure to avoid making the same mistakes from SYM-7968 through SYM-7970.

The code that used to populate these metrics was in `RouterService.routeDataForChannel()`. It also populated the `sym_node_host_channel_stats.data_unrouted` column, which was affected by the same issue. Rather than leaving this code in place, I removed it and had `RefreshUnroutedDataMetricsJob` populate both places. I kept the `routing.collect.stats.unrouted` parameter gate but changed its default value to `true` because the query will no longer slow down the Routing job.