### PR TITLE
SYM-7750: Ignore indexes on computed but not retained columns because they cannot be created on target database

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
@@ -246,8 +246,8 @@ public class ModelComparator {
             IIndex sourceIndex = findCorrespondingIndex(sourceTable, targetIndex);
             if (sourceIndex == null) {
                 String targetIndexName = targetIndex.getName();
-                if (!platformInfo.isPersistedGeneratedColumnsSupported() && targetTable.doesIndexContainPersistedGeneratedColumn(targetIndex)) {
-                    log.debug("Skipping index {} for table {} because it contains a persisted generated column that the target platform doesn't support",
+                if (!targetTable.canCreateIndex(targetIndex, platformInfo)) {
+                    log.debug("Skipping index {} for table {} because it references a generated column that the target platform can't index",
                             targetIndexName, sourceTableName);
                     continue;
                 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -54,6 +54,7 @@ import java.util.TreeSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jumpmind.db.platform.DatabaseInfo;
 
 /**
  * Represents a table in the database model.
@@ -361,6 +362,31 @@ public class Table extends Relation {
             }
         }
         return false;
+    }
+
+    public boolean doesIndexContainNonPersistedGeneratedColumn(IIndex index) {
+        for (int i = 0; i < index.getColumnCount(); i++) {
+            Column column = getColumnWithName(index.getColumn(i).getName());
+            if (column != null && column.isGenerated() && !column.isPersisted()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determines whether an index can be created on this table for the given platform. Generated columns that the platform can't index (either because it
+     * physically stores the value differently than the source, or because it doesn't materialize the value at all) are not indexable there, unless the platform
+     * doesn't support generated columns in the first place, in which case the column is replicated as a plain column and any index is fine.
+     */
+    public boolean canCreateIndex(IIndex index, DatabaseInfo databaseInfo) {
+        if (!databaseInfo.isGeneratedColumnsSupported()) {
+            return true;
+        }
+        if (doesIndexContainPersistedGeneratedColumn(index) && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
+            return false;
+        }
+        return !doesIndexContainNonPersistedGeneratedColumn(index) || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
     }
 
     public void sortForeignKeys(final boolean caseSensitive) {

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
@@ -2314,7 +2314,7 @@ public abstract class AbstractDdlBuilder implements IDdlBuilder {
         if (databaseInfo.isIndicesSupported()) {
             if (index.getName() == null) {
                 log.warn("Cannot write unnamed index " + index);
-            } else if (!table.doesIndexContainPersistedGeneratedColumn(index) || databaseInfo.isPersistedGeneratedColumnsSupported()) {
+            } else if (table.canCreateIndex(index, databaseInfo)) {
                 writeExternalIndexCreate(table, index, ddl);
                 printEndOfStatement(ddl);
             }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/DatabaseInfo.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/DatabaseInfo.java
@@ -96,6 +96,8 @@ public class DatabaseInfo {
     private boolean generatedColumnsSupported = false;
     /** Whether generated columns that physically store their value (e.g. SQL Server PERSISTED) are supported. */
     private boolean persistedGeneratedColumnsSupported = false;
+    /** Whether an index can be created on a generated column that isn't persisted (e.g. a virtual/non-materialized computed column). */
+    private boolean nonPersistedGeneratedColumnsIndexSupported = false;
     /** Whether expressions can be used as default values */
     private boolean expressionsAsDefaultValuesSupported = false;
     /** Whether functional indices are supported */
@@ -529,6 +531,25 @@ public class DatabaseInfo {
      */
     public void setPersistedGeneratedColumnsSupported(boolean persistedGeneratedColumnsSupported) {
         this.persistedGeneratedColumnsSupported = persistedGeneratedColumnsSupported;
+    }
+
+    /**
+     * Determines whether the platform supports creating an index on a generated column that isn't persisted (e.g. a virtual/non-materialized computed column).
+     *
+     * @return <code>true</code> if an index can be created on a non-persisted generated column
+     */
+    public boolean isNonPersistedGeneratedColumnsIndexSupported() {
+        return nonPersistedGeneratedColumnsIndexSupported;
+    }
+
+    /**
+     * Specifies whether the platform supports creating an index on a generated column that isn't persisted.
+     *
+     * @param nonPersistedGeneratedColumnsIndexSupported
+     *            <code>true</code> if an index can be created on a non-persisted generated column
+     */
+    public void setNonPersistedGeneratedColumnsIndexSupported(boolean nonPersistedGeneratedColumnsIndexSupported) {
+        this.nonPersistedGeneratedColumnsIndexSupported = nonPersistedGeneratedColumnsIndexSupported;
     }
 
     /**

--- a/symmetric-db/src/test/java/org/jumpmind/db/alter/ModelComparatorTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/alter/ModelComparatorTest.java
@@ -148,6 +148,7 @@ public class ModelComparatorTest {
     void detectIndexChanges_suppressesAddIndexChange_forPersistedGeneratedColumn_whenPlatformLacksPersistedSupport() {
         DatabaseInfo dbInfo = new DatabaseInfo();
         dbInfo.setIndicesSupported(true);
+        dbInfo.setGeneratedColumnsSupported(true);
         ModelComparator comparator = new ModelComparator(null, dbInfo, false);
         Column col = new Column("total");
         col.setGenerated(true);
@@ -165,7 +166,62 @@ public class ModelComparatorTest {
     void detectIndexChanges_addsIndexChange_forPersistedGeneratedColumn_whenPlatformSupportsPersisted() {
         DatabaseInfo dbInfo = new DatabaseInfo();
         dbInfo.setIndicesSupported(true);
+        dbInfo.setGeneratedColumnsSupported(true);
         dbInfo.setPersistedGeneratedColumnsSupported(true);
+        ModelComparator comparator = new ModelComparator(null, dbInfo, false);
+        Column col = new Column("total");
+        col.setGenerated(true);
+        col.setPersisted(true);
+        Table source = new Table("t");
+        Table target = new Table("t", col);
+        NonUniqueIndex index = new NonUniqueIndex("idx_total");
+        index.addColumn(new IndexColumn("total"));
+        target.addIndex(index);
+        comparator.detectIndexChanges(null, source, null, target, changeList);
+        assertEquals(1, changeList.size());
+        assertTrue(changeList.get(0) instanceof AddIndexChange);
+    }
+
+    @Test
+    void detectIndexChanges_suppressesAddIndexChange_forNonPersistedGeneratedColumn_whenPlatformLacksNonPersistedIndexSupport() {
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setIndicesSupported(true);
+        dbInfo.setGeneratedColumnsSupported(true);
+        ModelComparator comparator = new ModelComparator(null, dbInfo, false);
+        Column col = new Column("total");
+        col.setGenerated(true);
+        Table source = new Table("t");
+        Table target = new Table("t", col);
+        NonUniqueIndex index = new NonUniqueIndex("idx_total");
+        index.addColumn(new IndexColumn("total"));
+        target.addIndex(index);
+        comparator.detectIndexChanges(null, source, null, target, changeList);
+        assertEquals(0, changeList.size());
+    }
+
+    @Test
+    void detectIndexChanges_addsIndexChange_forNonPersistedGeneratedColumn_whenPlatformSupportsNonPersistedIndex() {
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setIndicesSupported(true);
+        dbInfo.setGeneratedColumnsSupported(true);
+        dbInfo.setNonPersistedGeneratedColumnsIndexSupported(true);
+        ModelComparator comparator = new ModelComparator(null, dbInfo, false);
+        Column col = new Column("total");
+        col.setGenerated(true);
+        Table source = new Table("t");
+        Table target = new Table("t", col);
+        NonUniqueIndex index = new NonUniqueIndex("idx_total");
+        index.addColumn(new IndexColumn("total"));
+        target.addIndex(index);
+        comparator.detectIndexChanges(null, source, null, target, changeList);
+        assertEquals(1, changeList.size());
+        assertTrue(changeList.get(0) instanceof AddIndexChange);
+    }
+
+    @Test
+    void detectIndexChanges_addsIndexChange_forGeneratedColumn_whenPlatformDoesNotSupportGeneratedColumns() {
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setIndicesSupported(true);
         ModelComparator comparator = new ModelComparator(null, dbInfo, false);
         Column col = new Column("total");
         col.setGenerated(true);

--- a/symmetric-db/src/test/java/org/jumpmind/db/model/TableTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/model/TableTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.jumpmind.db.platform.DatabaseInfo;
 import org.junit.jupiter.api.Test;
 
 class TableTest {
@@ -301,6 +302,77 @@ class TableTest {
     void doesIndexContainPersistedGeneratedColumn_returnsFalse_whenColumnNotInTable() {
         Table t = new Table("t", new Column("a"));
         assertFalse(t.doesIndexContainPersistedGeneratedColumn(indexOnColumns("unknown")));
+    }
+
+    @Test
+    void doesIndexContainNonPersistedGeneratedColumn_returnsFalse_forRegularColumn() {
+        Table t = new Table("t", new Column("a"));
+        assertFalse(t.doesIndexContainNonPersistedGeneratedColumn(indexOnColumns("a")));
+    }
+
+    @Test
+    void doesIndexContainNonPersistedGeneratedColumn_returnsTrue_forVirtualGeneratedColumn() {
+        Table t = new Table("t", generatedColumn("a", false));
+        assertTrue(t.doesIndexContainNonPersistedGeneratedColumn(indexOnColumns("a")));
+    }
+
+    @Test
+    void doesIndexContainNonPersistedGeneratedColumn_returnsFalse_forPersistedGeneratedColumn() {
+        Table t = new Table("t", generatedColumn("a", true));
+        assertFalse(t.doesIndexContainNonPersistedGeneratedColumn(indexOnColumns("a")));
+    }
+
+    @Test
+    void doesIndexContainNonPersistedGeneratedColumn_returnsTrue_whenMixedColumns() {
+        Table t = new Table("t", new Column("a"), generatedColumn("b", false));
+        assertTrue(t.doesIndexContainNonPersistedGeneratedColumn(indexOnColumns("a", "b")));
+    }
+
+    @Test
+    void doesIndexContainNonPersistedGeneratedColumn_returnsFalse_whenColumnNotInTable() {
+        Table t = new Table("t", new Column("a"));
+        assertFalse(t.doesIndexContainNonPersistedGeneratedColumn(indexOnColumns("unknown")));
+    }
+
+    @Test
+    void canCreateIndex_returnsTrue_whenGeneratedColumnsNotSupported() {
+        Table t = new Table("t", generatedColumn("a", true));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        assertTrue(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
+    @Test
+    void canCreateIndex_returnsFalse_forPersistedGeneratedColumn_whenPersistedNotSupported() {
+        Table t = new Table("t", generatedColumn("a", true));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        assertFalse(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
+    @Test
+    void canCreateIndex_returnsTrue_forPersistedGeneratedColumn_whenPersistedSupported() {
+        Table t = new Table("t", generatedColumn("a", true));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        dbInfo.setPersistedGeneratedColumnsSupported(true);
+        assertTrue(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
+    @Test
+    void canCreateIndex_returnsFalse_forNonPersistedGeneratedColumn_whenNonPersistedIndexNotSupported() {
+        Table t = new Table("t", generatedColumn("a", false));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        assertFalse(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
+    @Test
+    void canCreateIndex_returnsTrue_forNonPersistedGeneratedColumn_whenNonPersistedIndexSupported() {
+        Table t = new Table("t", generatedColumn("a", false));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        dbInfo.setNonPersistedGeneratedColumnsIndexSupported(true);
+        assertTrue(t.canCreateIndex(indexOnColumns("a"), dbInfo));
     }
 
     private static IIndex indexOnColumns(String... columnNames) {


### PR DESCRIPTION
Currently, we haven't added support for indexes on non-persisted generated columns to any database platform. I have created several development tickets to add this support.

For now, the `nonPersistedGeneratedColumnsIndexSupported` flag is set to `false` for all database platforms. Currently, this flag only matters when a source database that supports indexes on persisted generated columns sends a table definition to a target database that doesn't support persisted generated columns. In this case, the generated column becomes non-persisted in the target database, so SymmetricDS should not attempt to create the index.