### PR TITLE
SYM-7969: & SYM-7970: Fixed unrouted create time metrics query including routed rows and relying on cached data gaps

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -399,14 +399,9 @@ public class RouterService extends AbstractService implements IRouterService, IN
     }
 
     public List<ChannelDataCreateTimeRange> findUnroutedDataCreateTimeRangeByChannel() {
-        List<DataGap> dataGaps = gapDetector.getDataGaps();
-        if (dataGaps == null || dataGaps.isEmpty()) {
-            return Collections.emptyList();
-        }
-        GapQualifiedQuery query = buildGapQualifiedQuery(dataGaps,
-                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
-        return sqlTemplateDirty.query(query.sql(), (Row row) -> new ChannelDataCreateTimeRange(row.getString("channel_id"),
-                row.getDateTime("min_create_time"), row.getDateTime("max_create_time")), query.args(), query.types());
+        return sqlTemplateDirty.query(getSql("selectChannelDataCreateTimeRangeSql"),
+                (Row row) -> new ChannelDataCreateTimeRange(row.getString("channel_id"),
+                        row.getDateTime("min_create_time"), row.getDateTime("max_create_time")));
     }
 
     public List<ChannelDataUnroutedCount> findUnroutedDataCountByChannel() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterServiceSqlMap.java
@@ -29,12 +29,10 @@ public class RouterServiceSqlMap extends AbstractSqlMap {
         super(platform, replacementTokens);
         putSql("selectChannelsUsingGapsSql", "select distinct channel_id from $(data) where $(dataRange)");
         putSql("selectChannelsUsingStartDataId", "select distinct channel_id from $(data) where data_id >= ?");
-        putSql("selectChannelDataCreateTimeRangeUsingGapsSql",
-                "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
-                        + "from $(data) where $(dataRange) group by channel_id");
-        putSql("selectChannelDataCreateTimeRangeUsingStartDataId",
-                "select channel_id, min(create_time) as min_create_time, max(create_time) as max_create_time "
-                        + "from $(data) where data_id >= ? group by channel_id");
+        putSql("selectChannelDataCreateTimeRangeSql",
+                "select d.channel_id, min(d.create_time) as min_create_time, max(d.create_time) as max_create_time "
+                        + "from $(data_gap) g join $(data) d on d.data_id between g.start_id and g.end_id "
+                        + "where g.is_expired = 0 group by d.channel_id");
         putSql("selectChannelDataUnroutedCountSql",
                 "select d.channel_id, count(*) as unrouted_count from $(data_gap) g "
                         + "join $(data) d on d.data_id between g.start_id and g.end_id "

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -393,8 +393,8 @@ public class RouterServiceTest {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
         List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
         RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
-                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
-        assertTrue(query.sql().contains("group by channel_id"));
+                "selectChannelsUsingGapsSql", "selectChannelsUsingStartDataId");
+        assertTrue(query.sql().contains("distinct channel_id"));
         assertTrue(query.sql().contains("data_id between ? and ?"));
         assertEquals(4, query.args().length);
         assertEquals(1L, query.args()[0]);
@@ -408,7 +408,7 @@ public class RouterServiceTest {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 1);
         List<DataGap> gaps = Arrays.asList(new DataGap(1, 10), new DataGap(20, 30));
         RouterService.GapQualifiedQuery query = testRouterService.buildGapQualifiedQuery(gaps,
-                "selectChannelDataCreateTimeRangeUsingGapsSql", "selectChannelDataCreateTimeRangeUsingStartDataId");
+                "selectChannelsUsingGapsSql", "selectChannelsUsingStartDataId");
         assertTrue(query.sql().contains("data_id >= ?"));
         assertEquals(1, query.args().length);
         assertEquals(1L, query.args()[0]);
@@ -442,15 +442,13 @@ public class RouterServiceTest {
     @Test
     void testFindUnroutedDataCreateTimeRangeByChannelWithGapsMapsChannelDataCreateTimeRanges() {
         RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
-        testRouterService.gapDetector = mock(DataGapDetector.class);
-        when(testRouterService.gapDetector.getDataGaps()).thenReturn(Arrays.asList(new DataGap(1, 10)));
         Date minTime = new Date(1000L);
         Date maxTime = new Date(2000L);
         Row row = new Row(3);
         row.put("channel_id", "chan1");
         row.put("min_create_time", minTime);
         row.put("max_create_time", maxTime);
-        stubQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
+        stubNoArgQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
         List<ChannelDataCreateTimeRange> ranges = testRouterService.findUnroutedDataCreateTimeRangeByChannel();
         assertEquals(1, ranges.size());
         assertEquals("chan1", ranges.get(0).channelId());
@@ -459,8 +457,18 @@ public class RouterServiceTest {
     }
 
     @Test
-    void testFindUnroutedDataCreateTimeRangeByChannelReturnsEmptyListWhenGapsNotYetDetected() {
-        assertEquals(Collections.emptyList(), routerService.findUnroutedDataCreateTimeRangeByChannel());
+    void testFindUnroutedDataCreateTimeRangeByChannelIgnoresGapDetectorState() {
+        RouterService testRouterService = newRouterServiceForGapQuery(mock(IParameterService.class), 100, 100);
+        testRouterService.gapDetector = mock(DataGapDetector.class);
+        when(testRouterService.gapDetector.getDataGaps()).thenReturn(Collections.emptyList());
+        Row row = new Row(3);
+        row.put("channel_id", "chan1");
+        row.put("min_create_time", new Date(1000L));
+        row.put("max_create_time", new Date(2000L));
+        stubNoArgQueryToInvokeMapper(testRouterService.sqlTemplateDirty, Arrays.asList(row));
+        List<ChannelDataCreateTimeRange> ranges = testRouterService.findUnroutedDataCreateTimeRangeByChannel();
+        assertEquals(1, ranges.size());
+        assertEquals("chan1", ranges.get(0).channelId());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
I changed `findUnroutedDataCreateTimeRangeByChannel()` and its query to follow the pattern of `findUnroutedDataCountByChannel()`, which resolves both SYM-7969 and SYM-7970.