### PR TITLE
SYM-7737: Added support for distinguishing between STORED and VIRTUAL generated columns on PostgreSQL

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
@@ -82,6 +82,8 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
             }
         }
         platform.getDatabaseInfo().setGeneratedColumnsSupported(databaseMajorVersion >= 12);
+        platform.getDatabaseInfo().setPersistedGeneratedColumnsSupported(databaseMajorVersion >= 12);
+        platform.getDatabaseInfo().setNonPersistedGeneratedColumnsSupported(databaseMajorVersion >= 18);
         platform.getDatabaseInfo().setTriggersCreateOrReplaceSupported(versionSupportsReplaceTriggers);
         sharedTriggersDisabledFunction = this.parameterService.getTablePrefix() + "_triggers_disabled";
         sharedNodeDisabledFunction = this.parameterService.getTablePrefix() + "_node_disabled";

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialectTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialectTest.java
@@ -67,6 +67,7 @@ class PostgreSqlSymmetricDialectTest {
 
     @Test
     void constructor_enablesPersistedButNotNonPersistedGeneratedColumnSupport_atVersion14() {
+        setupWithMajorVersion(14);
         assertTrue(platform.getDatabaseInfo().isPersistedGeneratedColumnsSupported());
         assertFalse(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsSupported());
     }

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialectTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialectTest.java
@@ -20,8 +20,10 @@
  */
 package org.jumpmind.symmetric.db.postgresql;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,6 +52,38 @@ class PostgreSqlSymmetricDialectTest {
         sqlTemplate = mock(ISqlTemplate.class);
         when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
         when(sqlTemplate.getDatabaseMajorVersion()).thenReturn(14);
+        when(parameterService.getTablePrefix()).thenReturn("sym");
+        when(platform.getDdlBuilder()).thenReturn(new PostgreSqlDdlBuilder());
+        when(platform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        dialect = new PostgreSqlSymmetricDialect(parameterService, platform);
+    }
+
+    @Test
+    void constructor_disablesPersistedAndNonPersistedGeneratedColumnSupport_belowVersion12() {
+        setupWithMajorVersion(11);
+        assertFalse(platform.getDatabaseInfo().isPersistedGeneratedColumnsSupported());
+        assertFalse(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsSupported());
+    }
+
+    @Test
+    void constructor_enablesPersistedButNotNonPersistedGeneratedColumnSupport_atVersion14() {
+        assertTrue(platform.getDatabaseInfo().isPersistedGeneratedColumnsSupported());
+        assertFalse(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsSupported());
+    }
+
+    @Test
+    void constructor_enablesPersistedAndNonPersistedGeneratedColumnSupport_atVersion18() {
+        setupWithMajorVersion(18);
+        assertTrue(platform.getDatabaseInfo().isPersistedGeneratedColumnsSupported());
+        assertTrue(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsSupported());
+    }
+
+    private void setupWithMajorVersion(int majorVersion) {
+        IParameterService parameterService = mock(ParameterService.class);
+        platform = mock(IDatabasePlatform.class);
+        sqlTemplate = mock(ISqlTemplate.class);
+        when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
+        when(sqlTemplate.getDatabaseMajorVersion()).thenReturn(majorVersion);
         when(parameterService.getTablePrefix()).thenReturn("sym");
         when(platform.getDdlBuilder()).thenReturn(new PostgreSqlDdlBuilder());
         when(platform.getDatabaseInfo()).thenReturn(new DatabaseInfo());

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -375,25 +375,31 @@ public class Table extends Relation {
     }
 
     /**
-     * Determines whether an index can be created on this table for the given platform. Generated columns that the platform can't index (either because it
-     * physically stores the value differently than the source, or because it doesn't materialize the value at all) are not indexable there, unless the platform
-     * doesn't support generated columns in the first place, in which case the column is replicated as a plain column and any index is fine.
-     * <p>
-     * A platform that doesn't support non-persisted generated columns at all falls back to creating any such column as persisted instead, so a non-persisted
-     * source column is treated as persisted for this platform's indexing decision too.
+     * Determines whether an index can be created on this table for the given platform. The rules, applied in order:
+     * <ol>
+     * <li>If the platform doesn't support generated columns at all, every generated column is replicated as a plain column, so any index is fine.</li>
+     * <li>If the platform doesn't support non-persisted (virtual) generated columns (e.g. PostgreSQL before version 18), a non-persisted source column still
+     * ends up created as persisted there, so it's treated as persisted for the rest of this decision.</li>
+     * <li>An index touching a column that will be persisted needs the platform to support indexing persisted generated columns.</li>
+     * <li>An index touching a column that will stay non-persisted needs the platform to support indexing non-persisted generated columns.</li>
+     * </ol>
      */
     public boolean canCreateIndex(IIndex index, DatabaseInfo databaseInfo) {
         if (!databaseInfo.isGeneratedColumnsSupported()) {
             return true;
         }
-        boolean targetLacksNonPersistedSupport = !databaseInfo.isNonPersistedGeneratedColumnsSupported();
-        boolean hasPersistedColumn = doesIndexContainPersistedGeneratedColumn(index)
-                || (targetLacksNonPersistedSupport && doesIndexContainNonPersistedGeneratedColumn(index));
-        if (hasPersistedColumn && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
+        boolean indexHasPersistedGeneratedColumn = doesIndexContainPersistedGeneratedColumn(index);
+        boolean indexHasNonPersistedGeneratedColumn = doesIndexContainNonPersistedGeneratedColumn(index);
+        boolean targetSupportsNonPersistedGeneratedColumns = databaseInfo.isNonPersistedGeneratedColumnsSupported();
+        if (!targetSupportsNonPersistedGeneratedColumns) {
+            // a non-persisted source column is still created as persisted on this platform, so treat it as persisted here too
+            indexHasPersistedGeneratedColumn = indexHasPersistedGeneratedColumn || indexHasNonPersistedGeneratedColumn;
+            indexHasNonPersistedGeneratedColumn = false;
+        }
+        if (indexHasPersistedGeneratedColumn && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
             return false;
         }
-        boolean hasNonPersistedColumn = doesIndexContainNonPersistedGeneratedColumn(index) && !targetLacksNonPersistedSupport;
-        return !hasNonPersistedColumn || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
+        return !indexHasNonPersistedGeneratedColumn || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
     }
 
     public void sortForeignKeys(final boolean caseSensitive) {

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -390,8 +390,7 @@ public class Table extends Relation {
         }
         boolean indexHasPersistedGeneratedColumn = doesIndexContainPersistedGeneratedColumn(index);
         boolean indexHasNonPersistedGeneratedColumn = doesIndexContainNonPersistedGeneratedColumn(index);
-        boolean targetSupportsNonPersistedGeneratedColumns = databaseInfo.isNonPersistedGeneratedColumnsSupported();
-        if (!targetSupportsNonPersistedGeneratedColumns) {
+        if (!databaseInfo.isNonPersistedGeneratedColumnsSupported()) {
             // a non-persisted source column is still created as persisted on this platform, so treat it as persisted here too
             indexHasPersistedGeneratedColumn = indexHasPersistedGeneratedColumn || indexHasNonPersistedGeneratedColumn;
             indexHasNonPersistedGeneratedColumn = false;

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -378,15 +378,22 @@ public class Table extends Relation {
      * Determines whether an index can be created on this table for the given platform. Generated columns that the platform can't index (either because it
      * physically stores the value differently than the source, or because it doesn't materialize the value at all) are not indexable there, unless the platform
      * doesn't support generated columns in the first place, in which case the column is replicated as a plain column and any index is fine.
+     * <p>
+     * A platform that doesn't support non-persisted generated columns at all falls back to creating any such column as persisted instead, so a non-persisted
+     * source column is treated as persisted for this platform's indexing decision too.
      */
     public boolean canCreateIndex(IIndex index, DatabaseInfo databaseInfo) {
         if (!databaseInfo.isGeneratedColumnsSupported()) {
             return true;
         }
-        if (doesIndexContainPersistedGeneratedColumn(index) && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
+        boolean targetLacksVirtualSupport = !databaseInfo.isNonPersistedGeneratedColumnsSupported();
+        boolean hasPersistedColumn = doesIndexContainPersistedGeneratedColumn(index)
+                || (targetLacksVirtualSupport && doesIndexContainNonPersistedGeneratedColumn(index));
+        if (hasPersistedColumn && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
             return false;
         }
-        return !doesIndexContainNonPersistedGeneratedColumn(index) || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
+        boolean hasNonPersistedColumn = doesIndexContainNonPersistedGeneratedColumn(index) && !targetLacksVirtualSupport;
+        return !hasNonPersistedColumn || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
     }
 
     public void sortForeignKeys(final boolean caseSensitive) {

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -386,13 +386,13 @@ public class Table extends Relation {
         if (!databaseInfo.isGeneratedColumnsSupported()) {
             return true;
         }
-        boolean targetLacksVirtualSupport = !databaseInfo.isNonPersistedGeneratedColumnsSupported();
+        boolean targetLacksNonPersistedSupport = !databaseInfo.isNonPersistedGeneratedColumnsSupported();
         boolean hasPersistedColumn = doesIndexContainPersistedGeneratedColumn(index)
-                || (targetLacksVirtualSupport && doesIndexContainNonPersistedGeneratedColumn(index));
+                || (targetLacksNonPersistedSupport && doesIndexContainNonPersistedGeneratedColumn(index));
         if (hasPersistedColumn && !databaseInfo.isPersistedGeneratedColumnsSupported()) {
             return false;
         }
-        boolean hasNonPersistedColumn = doesIndexContainNonPersistedGeneratedColumn(index) && !targetLacksVirtualSupport;
+        boolean hasNonPersistedColumn = doesIndexContainNonPersistedGeneratedColumn(index) && !targetLacksNonPersistedSupport;
         return !hasNonPersistedColumn || databaseInfo.isNonPersistedGeneratedColumnsIndexSupported();
     }
 

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/DatabaseInfo.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/DatabaseInfo.java
@@ -96,6 +96,8 @@ public class DatabaseInfo {
     private boolean generatedColumnsSupported = false;
     /** Whether generated columns that physically store their value (e.g. SQL Server PERSISTED) are supported. */
     private boolean persistedGeneratedColumnsSupported = false;
+    /** Whether the platform supports generated columns whose value is computed on read rather than stored (e.g. PostgreSQL 18+ VIRTUAL). */
+    private boolean nonPersistedGeneratedColumnsSupported = true;
     /** Whether an index can be created on a generated column that isn't persisted (e.g. a virtual/non-materialized computed column). */
     private boolean nonPersistedGeneratedColumnsIndexSupported = false;
     /** Whether expressions can be used as default values */
@@ -531,6 +533,25 @@ public class DatabaseInfo {
      */
     public void setPersistedGeneratedColumnsSupported(boolean persistedGeneratedColumnsSupported) {
         this.persistedGeneratedColumnsSupported = persistedGeneratedColumnsSupported;
+    }
+
+    /**
+     * Determines whether the platform supports generated columns whose value is computed on read rather than stored.
+     *
+     * @return <code>true</code> if non-persisted (virtual) generated columns are supported
+     */
+    public boolean isNonPersistedGeneratedColumnsSupported() {
+        return nonPersistedGeneratedColumnsSupported;
+    }
+
+    /**
+     * Specifies whether the platform supports generated columns whose value is computed on read rather than stored.
+     *
+     * @param nonPersistedGeneratedColumnsSupported
+     *            <code>true</code> if non-persisted (virtual) generated columns are supported
+     */
+    public void setNonPersistedGeneratedColumnsSupported(boolean nonPersistedGeneratedColumnsSupported) {
+        this.nonPersistedGeneratedColumnsSupported = nonPersistedGeneratedColumnsSupported;
     }
 
     /**

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlBuilder.java
@@ -362,9 +362,13 @@ public class PostgreSqlDdlBuilder extends AbstractDdlBuilder {
         String definition = getDefinitionForGeneratedColumn(table, column);
         if (!StringUtils.isBlank(definition)) {
             if (!(definition.startsWith("(") && definition.endsWith(")"))) {
-                ddl.append(" GENERATED ALWAYS AS ").append("(").append(definition).append(") STORED");
+                definition = "(" + definition + ")";
+            }
+            ddl.append(" GENERATED ALWAYS AS ").append(definition);
+            if (!column.isPersisted() && databaseInfo.isNonPersistedGeneratedColumnsSupported()) {
+                ddl.append(" VIRTUAL");
             } else {
-                ddl.append(" GENERATED ALWAYS AS ").append(definition).append(" STORED");
+                ddl.append(" STORED");
             }
         }
     }

--- a/symmetric-db/src/test/java/org/jumpmind/db/model/TableTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/model/TableTest.java
@@ -375,6 +375,25 @@ class TableTest {
         assertTrue(t.canCreateIndex(indexOnColumns("a"), dbInfo));
     }
 
+    @Test
+    void canCreateIndex_returnsTrue_forNonPersistedGeneratedColumn_whenTargetLacksNonPersistedSupportButSupportsPersistedIndexing() {
+        Table t = new Table("t", generatedColumn("a", false));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        dbInfo.setNonPersistedGeneratedColumnsSupported(false);
+        dbInfo.setPersistedGeneratedColumnsSupported(true);
+        assertTrue(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
+    @Test
+    void canCreateIndex_returnsFalse_forNonPersistedGeneratedColumn_whenTargetLacksNonPersistedSupportAndPersistedIndexing() {
+        Table t = new Table("t", generatedColumn("a", false));
+        DatabaseInfo dbInfo = new DatabaseInfo();
+        dbInfo.setGeneratedColumnsSupported(true);
+        dbInfo.setNonPersistedGeneratedColumnsSupported(false);
+        assertFalse(t.canCreateIndex(indexOnColumns("a"), dbInfo));
+    }
+
     private static IIndex indexOnColumns(String... columnNames) {
         NonUniqueIndex index = new NonUniqueIndex();
         for (String name : columnNames) {

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlBuilderTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlBuilderTest.java
@@ -1,11 +1,19 @@
 package org.jumpmind.db.platform.postgresql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.sql.Types;
+
+import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.IIndex;
 import org.jumpmind.db.model.IndexColumn;
+import org.jumpmind.db.model.NonUniqueIndex;
+import org.jumpmind.db.model.PlatformColumn;
 import org.jumpmind.db.model.Table;
 import org.jumpmind.db.model.UniqueIndex;
+import org.jumpmind.db.platform.DatabaseNamesConstants;
 import org.junit.jupiter.api.Test;
 
 public class PostgreSqlDdlBuilderTest {
@@ -35,5 +43,61 @@ public class PostgreSqlDdlBuilderTest {
         ddlBuilder.writeExternalIndexCreate(table, index, ddl);
         String expectedDdl = "CREATE UNIQUE INDEX \"test_index\" ON \"test_table\" (\"test_column1\") INCLUDE (\"test_column2\")";
         assertEquals(expectedDdl, ddl.toString().trim());
+    }
+
+    @Test
+    void testWriteGeneratedColumn_persisted_emitsStoredKeyword() {
+        PostgreSqlDdlBuilder ddlBuilder = new PostgreSqlDdlBuilder();
+        ddlBuilder.getDatabaseInfo().setGeneratedColumnsSupported(true);
+        String sql = ddlBuilder.createTable(buildTableWithComputedColumn(true));
+        assertTrue(sql.contains("GENERATED ALWAYS AS"));
+        assertTrue(sql.contains("STORED"));
+        assertFalse(sql.contains("VIRTUAL"));
+    }
+
+    @Test
+    void testWriteGeneratedColumn_nonPersisted_emitsVirtualKeyword_whenTargetSupportsNonPersisted() {
+        PostgreSqlDdlBuilder ddlBuilder = new PostgreSqlDdlBuilder();
+        ddlBuilder.getDatabaseInfo().setGeneratedColumnsSupported(true);
+        ddlBuilder.getDatabaseInfo().setNonPersistedGeneratedColumnsSupported(true);
+        String sql = ddlBuilder.createTable(buildTableWithComputedColumn(false));
+        assertTrue(sql.contains("VIRTUAL"));
+        assertFalse(sql.contains("STORED"));
+    }
+
+    @Test
+    void testWriteGeneratedColumn_nonPersisted_fallsBackToStored_whenTargetLacksNonPersistedSupport() {
+        PostgreSqlDdlBuilder ddlBuilder = new PostgreSqlDdlBuilder();
+        ddlBuilder.getDatabaseInfo().setGeneratedColumnsSupported(true);
+        ddlBuilder.getDatabaseInfo().setNonPersistedGeneratedColumnsSupported(false);
+        String sql = ddlBuilder.createTable(buildTableWithComputedColumn(false));
+        assertTrue(sql.contains("STORED"));
+        assertFalse(sql.contains("VIRTUAL"));
+    }
+
+    @Test
+    void testWriteGeneratedColumn_indexRetained_whenPersistedGeneratedColumnsSupported() {
+        PostgreSqlDdlBuilder ddlBuilder = new PostgreSqlDdlBuilder();
+        ddlBuilder.getDatabaseInfo().setGeneratedColumnsSupported(true);
+        ddlBuilder.getDatabaseInfo().setPersistedGeneratedColumnsSupported(true);
+        Table table = buildTableWithComputedColumn(true);
+        NonUniqueIndex index = new NonUniqueIndex("idx_computed");
+        index.addColumn(new IndexColumn("total"));
+        table.addIndex(index);
+        String sql = ddlBuilder.createTable(table);
+        assertTrue(sql.contains("idx_computed"));
+    }
+
+    private Table buildTableWithComputedColumn(boolean persisted) {
+        Column idCol = new Column("id", true, Types.INTEGER, 0, 0);
+        Column aCol = new Column("a", false, Types.INTEGER, 0, 0);
+        Column bCol = new Column("b", false, Types.INTEGER, 0, 0);
+        Column computedCol = new Column("total");
+        computedCol.setMappedTypeCode(Types.INTEGER);
+        computedCol.setGenerated(true);
+        computedCol.setPersisted(persisted);
+        computedCol.setDefaultValue("(a + b)");
+        computedCol.addPlatformColumn(new PlatformColumn(DatabaseNamesConstants.POSTGRESQL, "INTEGER", 0, 0, null));
+        return new Table("test_computed", idCol, aCol, bCol, computedCol);
     }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -108,8 +108,44 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
         if (relation instanceof Table table) {
             detectAutoIncrementColumnsInUniqueIndices(table);
             readMetaDataAndPrimaryKeyConstraint(connection, table);
+            markGeneratedColumnStorageKind(connection, table, metaData.getMetaData().getDatabaseMajorVersion());
         }
         return relation;
+    }
+
+    /**
+     * Marks each of the table's generated columns as persisted (STORED) or not (VIRTUAL). VIRTUAL generated columns don't exist before PostgreSQL 18, so on
+     * older versions every generated column is necessarily STORED and no catalog query is needed; on 18+ both kinds are possible and have to be disambiguated
+     * via {@code pg_attribute.attgenerated}.
+     */
+    protected void markGeneratedColumnStorageKind(Connection connection, Table table, int databaseMajorVersion) throws SQLException {
+        if (!table.hasGeneratedColumns() || databaseMajorVersion < 12) {
+            return;
+        }
+        if (databaseMajorVersion < 18) {
+            for (Column column : table.getColumns()) {
+                if (column.isGenerated()) {
+                    column.setPersisted(true);
+                }
+            }
+            return;
+        }
+        String sql = "SELECT a.attname, a.attgenerated FROM pg_attribute a "
+                + "JOIN pg_class c ON a.attrelid = c.oid "
+                + "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                + "WHERE c.relname = ? AND n.nspname = ? AND a.attgenerated <> ''";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, table.getName());
+            ps.setString(2, table.getSchema());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Column column = table.findColumn(rs.getString(1));
+                    if (column != null) {
+                        column.setPersisted("s".equals(rs.getString(2)));
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -134,6 +134,7 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
                 + "JOIN pg_class c ON a.attrelid = c.oid "
                 + "JOIN pg_namespace n ON n.oid = c.relnamespace "
                 + "WHERE c.relname = ? AND n.nspname = ? AND a.attgenerated <> ''";
+        long startTimeMs = System.currentTimeMillis();
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setString(1, table.getName());
             ps.setString(2, table.getSchema());
@@ -145,6 +146,10 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
                     }
                 }
             }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Queried pg_attribute for generated columns. Table={}; Duration={} ms", table.getFullyQualifiedName(),
+                    System.currentTimeMillis() - startTimeMs);
         }
     }
 

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReaderTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1263,7 +1264,7 @@ class PostgreSqlDdlReaderTest {
         PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
         ddlReader.markGeneratedColumnStorageKind(connection, table, 14);
         assertTrue(generatedColumn.isPersisted());
-        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+        verify(connection, never()).prepareStatement(ArgumentMatchers.anyString());
     }
 
     @Test
@@ -1275,7 +1276,7 @@ class PostgreSqlDdlReaderTest {
         PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
         ddlReader.markGeneratedColumnStorageKind(connection, table, 11);
         assertFalse(generatedColumn.isPersisted());
-        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+        verify(connection, never()).prepareStatement(ArgumentMatchers.anyString());
     }
 
     @Test
@@ -1284,7 +1285,7 @@ class PostgreSqlDdlReaderTest {
         Connection connection = mock(Connection.class);
         PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
         ddlReader.markGeneratedColumnStorageKind(connection, table, 18);
-        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+        verify(connection, never()).prepareStatement(ArgumentMatchers.anyString());
     }
 
     @Test

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReaderTest.java
@@ -22,9 +22,11 @@ package org.jumpmind.db.platform.postgresql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
@@ -1250,6 +1252,60 @@ class PostgreSqlDdlReaderTest {
         assertEquals(index2, result);
         assertNull(ddlReader.findIndex("dne", indices));
         assertNull(ddlReader.findIndex("index2", Collections.emptyList()));
+    }
+
+    @Test
+    void testMarkGeneratedColumnStorageKind_marksAllGeneratedColumnsPersisted_belowVersion18_withoutQuerying() throws Exception {
+        Column generatedColumn = new Column("total");
+        generatedColumn.setGenerated(true);
+        Table table = new Table("test_table", generatedColumn);
+        Connection connection = mock(Connection.class);
+        PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
+        ddlReader.markGeneratedColumnStorageKind(connection, table, 14);
+        assertTrue(generatedColumn.isPersisted());
+        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void testMarkGeneratedColumnStorageKind_doesNothing_belowVersion12() throws Exception {
+        Column generatedColumn = new Column("total");
+        generatedColumn.setGenerated(true);
+        Table table = new Table("test_table", generatedColumn);
+        Connection connection = mock(Connection.class);
+        PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
+        ddlReader.markGeneratedColumnStorageKind(connection, table, 11);
+        assertFalse(generatedColumn.isPersisted());
+        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void testMarkGeneratedColumnStorageKind_doesNothing_whenTableHasNoGeneratedColumns() throws Exception {
+        Table table = new Table("test_table", new Column("a"));
+        Connection connection = mock(Connection.class);
+        PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
+        ddlReader.markGeneratedColumnStorageKind(connection, table, 18);
+        verify(connection, Mockito.never()).prepareStatement(ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void testMarkGeneratedColumnStorageKind_disambiguatesStoredAndVirtual_atVersion18() throws Exception {
+        Column storedColumn = new Column("stored_col");
+        storedColumn.setGenerated(true);
+        Column virtualColumn = new Column("virtual_col");
+        virtualColumn.setGenerated(true);
+        Table table = new Table("test_table", storedColumn, virtualColumn);
+        Connection connection = mock(Connection.class);
+        PreparedStatement ps = mock(PreparedStatement.class);
+        ResultSet rs = mock(ResultSet.class);
+        when(connection.prepareStatement(ArgumentMatchers.anyString())).thenReturn(ps);
+        when(ps.executeQuery()).thenReturn(rs);
+        when(rs.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+        when(rs.getString(1)).thenReturn("stored_col").thenReturn("virtual_col");
+        when(rs.getString(2)).thenReturn("s").thenReturn("v");
+        PostgreSqlDdlReader ddlReader = new PostgreSqlDdlReader(platform);
+        ddlReader.markGeneratedColumnStorageKind(connection, table, 18);
+        assertTrue(storedColumn.isPersisted());
+        assertFalse(virtualColumn.isPersisted());
     }
 
     protected String getResultSetSchemaName() {


### PR DESCRIPTION
Unlike other databases, before this change, Postgres actually only supported STORED generated columns. Support for VIRTUAL generated columns was added in Postgres 18.

The new `nonPersistedGeneratedColumnsSupported` flag in `DatabaseInfo` defaults to `true` because databases other than Postgres added support for non-persisted generated columns before (or at the same time as) they added support for persisted generated columns. The `generatedColumnsSupported` flag takes precedence, so if it's `false`, then this new flag won't be checked.