### PR TITLE
SYM-7751: Added support for MySQL virtual indexes

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mariadb/MariaDBSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mariadb/MariaDBSymmetricDialect.java
@@ -35,6 +35,7 @@ public class MariaDBSymmetricDialect extends MySqlSymmetricDialect {
         super(parameterService, platform);
         platform.getDatabaseInfo().setGeneratedColumnsSupported(!Version.isOlderThanVersion(getProductVersion(), "5.2"));
         platform.getDatabaseInfo().setPersistedGeneratedColumnsSupported(!Version.isOlderThanVersion(getProductVersion(), "5.2"));
+        platform.getDatabaseInfo().setNonPersistedGeneratedColumnsIndexSupported(false);
         platform.getDatabaseInfo().setExpressionsAsDefaultValuesSupported(false);
     }
 

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mysql/MySqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mysql/MySqlSymmetricDialect.java
@@ -101,6 +101,7 @@ public class MySqlSymmetricDialect extends AbstractSymmetricDialect implements I
         this.triggerTemplate = new MySqlTriggerTemplate(this, isConvertZeroDateToNull, characterSet);
         platform.getDatabaseInfo().setGeneratedColumnsSupported(!Version.isOlderThanVersion(version, "5.7.0"));
         platform.getDatabaseInfo().setPersistedGeneratedColumnsSupported(!Version.isOlderThanVersion(version, "5.7.0"));
+        platform.getDatabaseInfo().setNonPersistedGeneratedColumnsIndexSupported(!Version.isOlderThanVersion(version, "5.7.8"));
         platform.getDatabaseInfo().setExpressionsAsDefaultValuesSupported(!Version.isOlderThanVersion(version, "8.0.13"));
     }
 

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mysql/MySqlSymmetricDialectTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mysql/MySqlSymmetricDialectTest.java
@@ -54,10 +54,17 @@ class MySqlSymmetricDialectTest {
     }
 
     @Test
-    void constructor_neverEnablesNonPersistedGeneratedColumnsIndexSupport() {
-        IDatabasePlatform platform = createPlatform("8.0.0");
+    void constructor_disablesNonPersistedGeneratedColumnsIndexSupport_belowVersion578() {
+        IDatabasePlatform platform = createPlatform("5.7.7");
         new MySqlSymmetricDialect(createParameterService(), platform);
         assertFalse(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsIndexSupported());
+    }
+
+    @Test
+    void constructor_enablesNonPersistedGeneratedColumnsIndexSupport_atVersion578() {
+        IDatabasePlatform platform = createPlatform("5.7.8");
+        new MySqlSymmetricDialect(createParameterService(), platform);
+        assertTrue(platform.getDatabaseInfo().isNonPersistedGeneratedColumnsIndexSupported());
     }
 
     private IParameterService createParameterService() {

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilderTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilderTest.java
@@ -121,6 +121,21 @@ public class MySqlDdlBuilderTest {
         assertFalse(ddl.contains("idx_computed"), "Index on a non-persisted (VIRTUAL) generated column should be skipped");
     }
 
+    @Test
+    void testWriteGeneratedColumn_indexRetained_whenNonPersistedGeneratedColumnsIndexSupported() {
+        MySqlDdlBuilder ddlBuilder = new MySqlDdlBuilder();
+        ddlBuilder.getDatabaseInfo().setGeneratedColumnsSupported(true);
+        ddlBuilder.getDatabaseInfo().setPersistedGeneratedColumnsSupported(true);
+        ddlBuilder.getDatabaseInfo().setNonPersistedGeneratedColumnsIndexSupported(true);
+        Table table = buildTableWithComputedColumn(false);
+        NonUniqueIndex index = new NonUniqueIndex("idx_computed");
+        index.addColumn(new IndexColumn("total"));
+        table.addIndex(index);
+        String ddl = ddlBuilder.createTable(table);
+        assertTrue(ddl.contains("idx_computed"), "Expected index on non-persisted (VIRTUAL) generated column to be created "
+                + "when the platform supports indexing non-persisted generated columns");
+    }
+
     private Table buildTableWithComputedColumn(boolean persisted) {
         Column idCol = new Column("id", true, Types.INTEGER, 0, 0);
         Column aCol = new Column("a", false, Types.INTEGER, 0, 0);


### PR DESCRIPTION
Again I just had to enable the `nonPersistedGeneratedColumnsIndexSupported` flag for the appropriate version. It was necessary to disable the flag in `MariaDBSymmetricDialect` because it's a child of `MySqlSymmetricDialect` and leaving the flag enabled caused a unit test to fail. Support for MariaDB virtual indexes will be added in a separate PR for [SYM-7754](https://jumpmind.atlassian.net/browse/SYM-7754).

[SYM-7754]: https://jumpmind.atlassian.net/browse/SYM-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ